### PR TITLE
Privkey export import

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -392,19 +392,18 @@ PHP_FUNCTION(secp256k1_ec_pubkey_decompress) {
  */
 PHP_FUNCTION (secp256k1_ec_privkey_import) {
     secp256k1_context_t * context = SECP256K1_G(context);
-    zval *seckey;
-    unsigned char *privkey, *newseckey;
-    int privkeylen;
-    long compressed;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slz", &privkey, &privkeylen, &compressed, &seckey) == FAILURE) {
+
+    zval *zSecKey;
+    unsigned char *derkey;
+    int derkeylen;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz", &derkey, &derkeylen, &zSecKey) == FAILURE) {
         return;
     }
 
-    int result;
-    result = secp256k1_ec_privkey_import(context, newseckey, privkey, compressed);
-
+    unsigned char newseckey[32];
+    int result = secp256k1_ec_privkey_import(context, newseckey, derkey, derkeylen);
     if (result) {
-        ZVAL_STRING(seckey, newseckey, 1);
+        ZVAL_STRINGL(zSecKey, newseckey, 32, 1);
     }
 
     RETURN_LONG(result);
@@ -415,20 +414,19 @@ PHP_FUNCTION (secp256k1_ec_privkey_import) {
  */
 PHP_FUNCTION (secp256k1_ec_privkey_export) {
     secp256k1_context_t * context = SECP256K1_G(context);
-    zval *derkey;
-    unsigned char *seckey, *newkey;
-    int seckeylen, newkeylen, compressed;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slz", &seckey, &seckeylen, &compressed, &derkey) == FAILURE) {
+
+    zval *zDerKey;
+    unsigned char *seckey;
+    int seckeylen, compressed;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slz", &seckey, &seckeylen, &compressed, &zDerKey) == FAILURE) {
         return;
     }
 
-    newkey = Z_STRVAL_P(derkey);
-    newkeylen = 0;
-    int result;
-    result = secp256k1_ec_privkey_export(context, seckey, newkey, &newkeylen, compressed);
-
+    unsigned char newkey[300];
+    int newkeylen;
+    int result = secp256k1_ec_privkey_export(context, seckey, newkey, &newkeylen, compressed ? 1 : 0);
     if (result) {
-        ZVAL_STRINGL(derkey, newkey, newkeylen, 0);
+        ZVAL_STRINGL(zDerKey, newkey, newkeylen, 1);
     }
 
     RETURN_LONG(result);

--- a/tests/Secp256k1PrivkeyImportExportTest.php
+++ b/tests/Secp256k1PrivkeyImportExportTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BitWasp\Secp256k1Tests;
+
+
+use Symfony\Component\Yaml\Yaml;
+
+class Secp256k1PrivkeyImportExportTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    public function getPkVectors()
+    {
+        $parser = new Yaml();
+        $data = $parser->parse(__DIR__ . '/data/pubkey_create.yml');
+
+        $fixtures = array();
+        foreach ($data['vectors'] as $c => $vector) {
+            $fixtures[] = array(
+                $vector['seckey'],
+                ($c%2 == 0)
+            );
+        }
+        return $fixtures;
+    }
+
+    /**
+     * @dataProvider getPkVectors
+     * @param $seckey
+     * @param $compressed
+     */
+    public function testImportExport($seckey, $compressed)
+    {
+        $seckey = $this->toBinary32($seckey);
+
+        $der = '';
+        $r = secp256k1_ec_privkey_export($seckey, $compressed, $der);
+        $this->assertEquals(1, $r);
+
+        $recovered = '';
+        $r = secp256k1_ec_privkey_import($der, $recovered);
+        $this->assertEquals(1, $r);
+
+
+        $this->assertEquals($seckey, $recovered);
+
+    }
+}


### PR DESCRIPTION
The functions secp256k1_ec_privkey_export and secp256k1_ec_privkey_import in master currently segfault if used. This PR fixes them, and adds tests for consistency. 

I tried decoding the exported DER key with PhpEcc which failed.. I noticed the DER keys produced by both are of a different size, so I'll try it against openssl and see if it has any issues. 