### PR TITLE
Take the length of the gievn zval's string, instead of requiring the …

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -516,18 +516,17 @@ PHP_FUNCTION (secp256k1_ec_pubkey_tweak_mul) {
     secp256k1_context_t * context = SECP256K1_G(context);
 
     zval *pubkey;
-    int pubkeylen;
     unsigned char *tweak, *newpubkey;
     int tweaklen, newpubkeylen;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zls", &pubkey, &pubkeylen, &tweak, &tweaklen) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zs", &pubkey, &tweak, &tweaklen) == FAILURE) {
         return;
     }
 
     newpubkey = Z_STRVAL_P(pubkey);
     newpubkeylen = Z_STRLEN_P(pubkey);
     int result;
-    result = secp256k1_ec_pubkey_tweak_mul(context, newpubkey, pubkeylen, tweak);
+    result = secp256k1_ec_pubkey_tweak_mul(context, newpubkey, newpubkeylen, tweak);
 
     if (result) {
         ZVAL_STRINGL(pubkey, newpubkey, newpubkeylen, 0);

--- a/tests/Secp256k1PubkeyTweakMulTest.php
+++ b/tests/Secp256k1PubkeyTweakMulTest.php
@@ -55,7 +55,7 @@ class Secp256k1PubkeyTweakMulTest extends TestCase
     {
         $publicKey = $this->toBinary32($publicKey);
         $tweak = $this->toBinary32($tweak);
-        $result = secp256k1_ec_pubkey_tweak_mul($publicKey, strlen($publicKey), $tweak);
+        $result = secp256k1_ec_pubkey_tweak_mul($publicKey, $tweak);
         $this->assertEquals($eMul, $result);
         $this->assertEquals($expectedPublicKey, bin2hex($publicKey));
     }


### PR DESCRIPTION
…user pass the public key's length, in secp256k1_ec_pubkey_tweak_mul()