### PR TITLE
Update code to use latest secp256k1 api. Instead of modifying the $pu…

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -51,7 +51,8 @@ ZEND_BEGIN_ARG_INFO(arginfo_secp256k1_ec_pubkey_create, 0)
 ZEND_END_ARG_INFO();
 
 ZEND_BEGIN_ARG_INFO(arginfo_secp256k1_ec_pubkey_decompress, 0)
-    ZEND_ARG_INFO(1, publicKey)
+    ZEND_ARG_INFO(0, publicKeyIn)
+    ZEND_ARG_INFO(1, publicKeyOut)
 ZEND_END_ARG_INFO();
 
 ZEND_BEGIN_ARG_INFO(arginfo_secp256k1_ec_privkey_import, 0)
@@ -370,15 +371,11 @@ PHP_FUNCTION(secp256k1_ec_pubkey_decompress) {
     zval *zPubKey;
     unsigned char *pubkey, newpubkey[65];
     int pubkeylen;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zPubKey) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sz", &pubkey, &pubkeylen, &zPubKey) == FAILURE) {
         return;
     }
 
-    pubkey = Z_STRVAL_P(zPubKey);
-    pubkeylen = Z_STRLEN_P(zPubKey);
-    memcpy(newpubkey, pubkey, pubkeylen);
-    int result;
-    result = secp256k1_ec_pubkey_decompress(context, newpubkey, &pubkeylen);
+    int result = secp256k1_ec_pubkey_decompress(context, pubkey, newpubkey, &pubkeylen);
 
     if (result == 1) {
         ZVAL_STRINGL(zPubKey, newpubkey, pubkeylen, 1);

--- a/tests/Secp256k1PubkeyDecompressTest.php
+++ b/tests/Secp256k1PubkeyDecompressTest.php
@@ -30,26 +30,10 @@ class Secp256k1PubkeyDecompressTest extends TestCase
     public function testDecompressesPubkey($expectedCompressed, $expectedUncompressed)
     {
         $publickey = $this->toBinary32($expectedCompressed);
-
-        $result = secp256k1_ec_pubkey_decompress($publickey);
+        $decompressed = '';
+        $result = secp256k1_ec_pubkey_decompress($publickey, $decompressed);
         $this->assertEquals(1, $result, 'check for success');
-        $this->assertEquals($expectedUncompressed, bin2hex($publickey));
+        $this->assertEquals($expectedUncompressed, bin2hex($decompressed));
     }
 
-    /**
-     *
-     */
-    public function testByRef()
-    {
-        $o = $this->toBinary32("03ca473d3c0cccbf600d1c89fa33b7f6b1f2b4c66f1f11986701f4b6cc4f54c360");
-        $a = $this->toBinary32("03ca473d3c0cccbf600d1c89fa33b7f6b1f2b4c66f1f11986701f4b6cc4f54c360");
-        $b = $a;
-        
-        $r = secp256k1_ec_pubkey_decompress($b);
-        
-        $this->assertEquals(1, $r);
-        $this->assertTrue($b != $o, '$b is decompressed');
-        $this->assertTrue($a == $o, '$a is not decompressed');
-        
-    }
 }


### PR DESCRIPTION
…blicKey variable passed to secp256k1_ec_pubkey_decompress(), it now sets the value to the second variable.