### PR TITLE
Fix secp256k1_ecdsa_signature_normalize

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -509,7 +509,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
     secp256k1_context *ctx;
     secp256k1_ecdsa_signature *sigout, *sigin;
     int result;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rrr", &zCtx, &zSigOut, &zSigIn) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/r", &zCtx, &zSigOut, &zSigIn) == FAILURE) {
         RETURN_FALSE;
     }
 
@@ -521,13 +521,12 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
         RETURN_FALSE;
     }
 
+    zval_dtor(zSigOut);
+
     sigout = emalloc(sizeof(secp256k1_ecdsa_signature));
     result = secp256k1_ecdsa_signature_normalize(ctx, sigout, sigin);
-    if (result == 1) {
-        Z_RES_P(zSigOut)->ptr = zend_register_resource(sigout, le_secp256k1_sig);
-    } else {
-        efree(sigout);
-    }
+
+    ZVAL_RES(zSigOut, zend_register_resource(sigout, le_secp256k1_sig));
 
     RETURN_LONG(result);
 }

--- a/tests/Secp256k1EcdsaSignTest.php
+++ b/tests/Secp256k1EcdsaSignTest.php
@@ -54,9 +54,13 @@ class Secp256k1EcdsaSignTest extends TestCase
 
         $this->assertEquals($eSigCreate, $sign);
         $this->assertEquals(SECP256K1_TYPE_SIG, get_resource_type($signature));
-        
-        return;
 
+        $normalized = null;
+        secp256k1_ecdsa_signature_normalize($context, $normalized, $signature);
+
+        $sigSerOut = null;
+        $this->assertEquals(1, secp256k1_ecdsa_signature_serialize_der($context, $sigSerOut, $normalized));
+        $this->assertEquals($expectedSig, unpack("H*", $sigSerOut)[1]);
     }
 
     public function getErroneousTypeVectors()


### PR DESCRIPTION
This function was untested, and was found to be
broken when I was using it in tests.

This allows an arbitrary value to be passed as
the second parameter, where the normalized signature
resource will be written.

It also fixes a logic error I had in the function,
which meant the signature would only be written IFF
the sigin was not in normalized form.