### PR TITLE
Typo in composer.json license, and drop 5.3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,5 @@
         "squizlabs/php_codesniffer": "2.*",
         "symfony/yaml": "*"
     },
-    "license": "Unlicence"
+    "license": "Unlicense"
 }


### PR DESCRIPTION
The first commit shown that 5.3 builds are broken right now, travis only has support for that on precise.. Not really bothered tweaking things just to test something that old.