### PR TITLE
secp256k1_context_randomize - implement spec properly

### DIFF
--- a/secp256k1/tests/secp256k1_context_randomize_basic.phpt
+++ b/secp256k1/tests/secp256k1_context_randomize_basic.phpt
@@ -6,12 +6,24 @@ if (!extension_loaded("secp256k1")) print "skip extension not loaded";
 ?>
 --FILE--
 <?php
-$ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+$ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 echo get_resource_type($ctx) . "\n";
 
+$state1 = str_repeat("\x42", 32);
+$result = secp256k1_context_randomize($ctx, $state1);
+echo $result . PHP_EOL;
+
+// reset operation
+$result = secp256k1_context_randomize($ctx, null);
+echo $result . PHP_EOL;
+
+// reset operation (implicit)
 $result = secp256k1_context_randomize($ctx);
 echo $result . PHP_EOL;
+
 ?>
 --EXPECT--
 secp256k1_context
+1
+1
 1

--- a/secp256k1/tests/secp256k1_context_randomize_error3.phpt
+++ b/secp256k1/tests/secp256k1_context_randomize_error3.phpt
@@ -1,0 +1,22 @@
+--TEST--
+secp256k1_context_randomize throws an exception if not byte32/null
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+$ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+echo get_resource_type($ctx) . "\n";
+
+$state1 = 1;
+try {
+    \secp256k1_context_randomize($ctx, $state1);
+} catch (\Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+?>
+--EXPECT--
+secp256k1_context
+secp256k1_context_randomize(): Parameter 2 should be a 32 byte string, or null

--- a/secp256k1/tests/secp256k1_context_randomize_error4.phpt
+++ b/secp256k1/tests/secp256k1_context_randomize_error4.phpt
@@ -1,0 +1,22 @@
+--TEST--
+secp256k1_context_randomize throws an exception if not string not 32 bytes
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+$ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+echo get_resource_type($ctx) . "\n";
+
+$state1 = str_repeat("a", 31);
+try {
+    \secp256k1_context_randomize($ctx, $state1);
+} catch (\Exception $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+?>
+--EXPECT--
+secp256k1_context
+secp256k1_context_randomize(): Parameter 2 should be 32 bytes


### PR DESCRIPTION
We never checked the length of input to this function.
Also, it should be possible to reset the state by passing
null (or not passing a second parameter)

`secp256k1_context_randomize($context); // reset state`
`secp256k1_context_randomize($context, null); // reset state`
`secp256k1_context_randomize($context, $seed32); // update randomization`

Adds tests for coverage, though no real way to probe this
functions internals...