### PR TITLE
Doc updates, and extract commonly used functions

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -271,6 +271,11 @@ static secp256k1_ecdsa_recoverable_signature* php_get_secp256k1_ecdsa_recoverabl
     return (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(precsig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1);
 }
 
+// attempt to read a sec256k1_pubkey* from the provided resource zval
+static secp256k1_pubkey* php_get_secp256k1_pubkey(zval *pkey) {
+    return (secp256k1_pubkey *)zend_fetch_resource2_ex(pkey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1);
+}
+
 PHP_MINIT_FUNCTION(secp256k1) {
     le_secp256k1_ctx = zend_register_list_destructors_ex(secp256k1_ctx_dtor, NULL, SECP256K1_CTX_RES_NAME, module_number);
     le_secp256k1_pubkey = zend_register_list_destructors_ex(secp256k1_pubkey_dtor, NULL, SECP256K1_PUBKEY_RES_NAME, module_number);
@@ -577,7 +582,7 @@ PHP_FUNCTION(secp256k1_ecdsa_verify) {
         RETURN_FALSE;
     }
 
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+    if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -753,7 +758,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_negate)
         RETURN_FALSE;
     }
 
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+    if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -812,7 +817,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_serialize)
         RETURN_FALSE;
     }
 
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+    if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -892,7 +897,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_add)
         RETURN_FALSE;
     }
 
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, 0)) == NULL) {
+    if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -969,7 +974,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_mul)
         RETURN_FALSE;
     }
 
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+    if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1004,7 +1009,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_combine)
     const secp256k1_pubkey * pubkeys[array_count];
 
     ZEND_HASH_FOREACH_KEY_VAL(arr_hash, i, arrayKeyStr, arrayPubKey) {
-        if ((ptr = (secp256k1_pubkey *)zend_fetch_resource2_ex(arrayPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+        if ((ptr = php_get_secp256k1_pubkey(arrayPubKey)) == NULL) {
             RETURN_FALSE;
         }
 
@@ -1234,7 +1239,7 @@ PHP_FUNCTION(secp256k1_ecdh)
         RETURN_FALSE;
     }
 
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+    if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_FALSE;
     }
 

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -266,6 +266,11 @@ static secp256k1_ecdsa_signature* php_get_secp256k1_ecdsa_signature(zval *psig) 
     return (secp256k1_ecdsa_signature *)zend_fetch_resource2_ex(psig, SECP256K1_SIG_RES_NAME, le_secp256k1_sig, -1);
 }
 
+// attempt to read a sec256k1_ecdsa_recoverable_signature* from the provided resource zval
+static secp256k1_ecdsa_recoverable_signature* php_get_secp256k1_ecdsa_recoverable_signature(zval *precsig) {
+    return (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(precsig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1);
+}
+
 PHP_MINIT_FUNCTION(secp256k1) {
     le_secp256k1_ctx = zend_register_list_destructors_ex(secp256k1_ctx_dtor, NULL, SECP256K1_CTX_RES_NAME, module_number);
     le_secp256k1_pubkey = zend_register_list_destructors_ex(secp256k1_pubkey_dtor, NULL, SECP256K1_PUBKEY_RES_NAME, module_number);
@@ -1080,7 +1085,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_convert)
         RETURN_FALSE;
     }
 
-    if ((rSig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zRecoverableSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1)) == NULL) {
+    if ((rSig = php_get_secp256k1_ecdsa_recoverable_signature(zRecoverableSig)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1115,7 +1120,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
         RETURN_FALSE;
     }
 
-    if ((recsig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zRecSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1)) == NULL) {
+    if ((recsig = php_get_secp256k1_ecdsa_recoverable_signature(zRecSig)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1191,7 +1196,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recover)
         RETURN_FALSE;
     }
 
-    if ((sig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, 0)) == NULL) {
+    if ((sig = php_get_secp256k1_ecdsa_recoverable_signature(zSig)) == NULL) {
         RETURN_FALSE;
     }
 

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -256,6 +256,11 @@ static void secp256k1_recoverable_sig_dtor(zend_resource * rsrc TSRMLS_DC)
     }
 }
 
+// attempt to read a sec256k1_context* from the provided resource
+static secp256k1_context* php_get_secp256k1_context(zval* pcontext) {
+    return (secp256k1_context *)zend_fetch_resource2_ex(pcontext, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1);
+}
+
 PHP_MINIT_FUNCTION(secp256k1) {
     le_secp256k1_ctx = zend_register_list_destructors_ex(secp256k1_ctx_dtor, NULL, SECP256K1_CTX_RES_NAME, module_number);
     le_secp256k1_pubkey = zend_register_list_destructors_ex(secp256k1_pubkey_dtor, NULL, SECP256K1_PUBKEY_RES_NAME, module_number);
@@ -364,7 +369,7 @@ PHP_FUNCTION(secp256k1_context_clone)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -386,7 +391,7 @@ PHP_FUNCTION(secp256k1_context_randomize)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -426,7 +431,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_der)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -460,7 +465,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_parse_der)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -491,7 +496,7 @@ PHP_FUNCTION(ecdsa_signature_parse_der_lax)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -520,7 +525,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -554,7 +559,7 @@ PHP_FUNCTION(secp256k1_ecdsa_verify) {
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -589,7 +594,7 @@ PHP_FUNCTION (secp256k1_ecdsa_sign)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -631,7 +636,7 @@ PHP_FUNCTION(secp256k1_ec_seckey_verify)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -662,7 +667,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_create)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -697,7 +702,7 @@ PHP_FUNCTION(secp256k1_ec_privkey_negate)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -734,7 +739,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_negate)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -762,7 +767,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_parse)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -793,7 +798,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_serialize)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -830,7 +835,7 @@ PHP_FUNCTION(secp256k1_ec_privkey_tweak_add)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, 0)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -873,7 +878,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_add)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, 0)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -905,7 +910,7 @@ PHP_FUNCTION(secp256k1_ec_privkey_tweak_mul)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -950,7 +955,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_mul)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -980,7 +985,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_combine)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -313,13 +313,8 @@ zend_module_entry secp256k1_module_entry = {
 ZEND_GET_MODULE(secp256k1)
 #endif
 
-/** Create a secp256k1 context object.
- *  $secp256k1Context = secp256k1_context_create(int $flags);
- *  Returns: a newly created context object, or false if an error occurred.
- *  In:      flags: which parts of the context to initialize.
- *
- *  See also secp256k1_context_randomize.
- */
+/* {{{ proto resource secp256k1_context_create(int flags)
+ * Create a secp256k1 context object. */
 PHP_FUNCTION(secp256k1_context_create)
 {
     long flags;
@@ -335,12 +330,10 @@ PHP_FUNCTION(secp256k1_context_create)
     ctx = secp256k1_context_create(flags);
     RETURN_RES(zend_register_resource(ctx, le_secp256k1_ctx));
 }
+/* }}} */
 
-/** Destroy a secp256k1 context object.
- *  $resultFlag = secp256k1_context_destroy(resource $context);
- *  The context pointer may not be used afterwards.
- *  Args:   ctx: an existing context to destroy (cannot be NULL)
- */
+/* {{{ proto secp256k1_context_destroy(resource context)
+ * Destroy a secp256k1 context object. */
 PHP_FUNCTION(secp256k1_context_destroy)
 {
     zval *zCtx;
@@ -359,11 +352,8 @@ PHP_FUNCTION(secp256k1_context_destroy)
 }
 /* }}} */
 
-/** Copies a secp256k1 context object.
- *  $cloneContext = secp256k1_context_clone($context);
- *  Returns: a newly created context object.
- *  Args:    ctx: an existing context to copy (cannot be NULL)
- */
+/* {{{ proto resource secp256k1_context_clone(resource context)
+ * Copies a secp256k1 context object. */
 PHP_FUNCTION(secp256k1_context_clone)
 {
     zval *zCtx;
@@ -384,13 +374,8 @@ PHP_FUNCTION(secp256k1_context_clone)
 }
 /* }}} */
 
-/** Updates the context randomization
- *  secp256k1_context_randomize(resource $context, [string $bytes32 = NULL])
- *  In:   ctx:    a context resource
- *        seed32: a random 32-byte seed (NULL resets to initial state)
- *  Out:  0:      an error occured
- *        1:      randomization successfully updated
- */
+/* {{{ proto int secp256k1_context_randomize(resource context, [string bytes32 = NULL])
+ * Updates the context randomization. */
 PHP_FUNCTION(secp256k1_context_randomize)
 {
     zval *zCtx, *zSeed = NULL;
@@ -426,17 +411,8 @@ PHP_FUNCTION(secp256k1_context_randomize)
 }
 /* }}} */
 
-/** Serialize an ECDSA signature in DER format.
- *
- *  Returns: 1 if enough space was available to serialize, 0 otherwise
- *  Args:   ctx:       a secp256k1 context object
- *  Out:    output:    a pointer to an array to store the DER serialization
- *  In/Out: outputlen: a pointer to a length integer. Initially, this integer
- *                     should be set to the length of output. After the call
- *                     it will be set to the length of the serialization (even
- *                     if 0 was returned).
- *  In:     sig:       a pointer to an initialized signature object
- */
+/* {{{ proto int secp256k1_ec_signature_serialize_der(resource context, string &sigOut, resource sig)
+ * Serialize an ECDSA signature in DER format. */
 PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_der)
 {
     zval *zCtx, *zSig, *zSigOut;
@@ -470,13 +446,8 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_der)
 }
 /* }}} */
 
-/** Parse a DER signature into a signature resource
- *  {{{ proto int secp256k1_ecdsa_signature_parse_der(
- *         resource secp256k1_context,
- *         resource & secp256k1_ecdsa_signature,
- *         string serializedSignature
- *     );
- */
+/* {{{ proto int secp256k1_ecdsa_signature_parse_der(resource ctx, resource &sig, string sigIn)
+ * Parse a DER ECDSA signature. */
 PHP_FUNCTION(secp256k1_ecdsa_signature_parse_der)
 {
     zval *zCtx, *zSig;
@@ -506,14 +477,8 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_parse_der)
 }
 /* }}} */
 
-/* Parse a DER signature into a signature resource */
-/**
- * {{{ proto int ecdsa_signature_parse_der_lax(
- *         resource secp256k1_context,
- *         resource & secp256k1_ecdsa_signature_out
- *         string $signature_in
- *     );
- */
+/* {{{ proto int ecdsa_signature_parse_der_lax(resource context, resource &sigOut, string sigIn)
+ * Parse a signature in "lax DER" format. */
 PHP_FUNCTION(ecdsa_signature_parse_der_lax)
 {
     zval *zCtx, *zSig;
@@ -541,15 +506,10 @@ PHP_FUNCTION(ecdsa_signature_parse_der_lax)
 
     RETURN_LONG(result);
 }
+/* }}} */
 
-/* Parse a DER signature into a signature resource */
-/**
- * {{{ proto int secp256k1_ecdsa_signature_normalize(
- *         resource secp256k1_context,
- *         resource & secp256k1_ecdsa_signature_out
- *         resource secp256k1_ecdsa_signature_in
- *     );
- */
+/* {{{ proto int secp256k1_ecdsa_signature_normalize(resource context, resource &sigNormal, resource sig)
+ * Convert a signature to a normalized lower-S form. */
 PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
 {
     zval *zCtx, *zSigIn, *zSigOut;
@@ -579,18 +539,8 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
 }
 /* }}} */
 
-
-/**
- * Verify an ECDSA signature.
- *
- * In:
- *  msg32: the 32-byte message hash being verified (cannot be NULL)
- *  sig: the signature resource being verified (cannot be NULL)
- *  pubkey: the public key resource to verify with (cannot be NULL)
- * Returns:
- *  1: correct signature
- *  0: incorrect signature
- */
+/* {{{ proto int secp256k1_ecdsa_verify(resource context, resource sig, string msg32, resource pubKey)
+ * Verify an ECDSA signature. */
 PHP_FUNCTION(secp256k1_ecdsa_verify) {
     zval *zCtx, *zSig, *zPubKey;
     secp256k1_context *ctx;
@@ -625,47 +575,8 @@ PHP_FUNCTION(secp256k1_ecdsa_verify) {
 }
 /* }}} */
 
-/**
- * Create an ECDSA signature.
- *
- * In:
- *  msg32:  the 32-byte message hash being signed (cannot be NULL)
- *  seckey: pointer to a 32-byte secret key (cannot be NULL)
- *
- * Out:
- *  sig:    pointer to an array where the signature will be placed (cannot be NULL)
- *
- * Returns:
- *  1: signature created
- *  0: the nonce generation function failed, the private key was invalid, or there is not
- *     enough space in the signature.
- *
- * The sig always has an s value in the lower half of the range (From 0x1
- * to 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
- * inclusive), unlike many other implementations.
- * With ECDSA a third-party can can forge a second distinct signature
- * of the same message given a single initial signature without knowing
- * the key by setting s to its additive inverse mod-order, 'flipping' the
- * sign of the random point R which is not included in the signature.
- * Since the forgery is of the same message this isn't universally
- * problematic, but in systems where message malleability or uniqueness
- * of signatures is important this can cause issues.  This forgery can be
- * blocked by all verifiers forcing signers to use a canonical form. The
- * lower-S form reduces the size of signatures slightly on average when
- * variable length encodings (such as DER) are used and is cheap to
- * verify, making it a good choice. Security of always using lower-S is
- * assured because anyone can trivially modify a signature after the
- * fact to enforce this property.  Adjusting it inside the signing
- * function avoids the need to re-serialize or have curve specific
- * constants outside of the library.  By always using a canonical form
- * even in applications where it isn't needed it becomes possible to
- * impose a requirement later if a need is discovered.
- * No other forms of ECDSA malleability are known and none seem likely,
- * but there is no formal proof that ECDSA, even with this additional
- * restriction, is free of other malleability.  Commonly used serialization
- * schemes will also accept various non-unique encodings, so care should
- * be taken when this property is required for an application.
- */
+/* {{{ proto int secp256k1_ecdsa_sign(resource context, resource &sig, string msg32, string key32)
+ * Create an ECDSA signature. */
 PHP_FUNCTION (secp256k1_ecdsa_sign)
 {
     zval *zCtx, *zSig;
@@ -707,12 +618,8 @@ PHP_FUNCTION (secp256k1_ecdsa_sign)
 }
 /* }}} */
 
-/** Verify an ECDSA secret key.
- *  Returns: 1: secret key is valid
- *           0: secret key is invalid
- *  In:      ctx: pointer to a context object (cannot be NULL)
- *           seckey: pointer to a 32-byte secret key (cannot be NULL)
- */
+/* {{{ proto int secp256k1_ec_seckey_verify(resource context, string key32)
+ * Verify an ECDSA secret key. */
 PHP_FUNCTION(secp256k1_ec_seckey_verify)
 {
     zval *zCtx;
@@ -739,21 +646,8 @@ PHP_FUNCTION(secp256k1_ec_seckey_verify)
 }
 /* }}} */
 
-/**
- * Compute the public key for a secret key.
- *
- * In:
- *  compressed: whether the computed public key should be compressed
- *  seckey:     pointer to a 32-byte private key (cannot be NULL)
- *
- * Out:
- *  pubkey:     pointer to a 33-byte (if compressed) or 65-byte (if uncompressed)
- *              area to store the public key (cannot be NULL)
- *
- * Returns:
- *  1: secret was valid, public key stored
- *  0: secret was invalid, try again.
- */
+/* {{{ proto int secp256k1_ec_pubkey_create(resource context, resource &pubKey, string key32)
+ * Compute the public key for a secret key. */
 PHP_FUNCTION(secp256k1_ec_pubkey_create)
 {
     zval *zCtx;
@@ -790,11 +684,8 @@ PHP_FUNCTION(secp256k1_ec_pubkey_create)
 }
 /* }}} */
 
-/** Negates a private key in place.
- *  Returns: 1 always
- *  Args:   ctx:        pointer to a context object
- *  In/Out: pubkey:     pointer to the public key to be negated (cannot be NULL)
- */
+/* {{{ proto int secp256k1_ec_privkey_negate(resource context, string key32)
+ * Negates a private key in place. */
 PHP_FUNCTION(secp256k1_ec_privkey_negate)
 {
     zval *zCtx, *zPrivKey;
@@ -828,12 +719,10 @@ PHP_FUNCTION(secp256k1_ec_privkey_negate)
 
     RETURN_LONG(result);
 }
+/* }}} */
 
-/** Negates a private key in place.
- *  Returns: 1 always
- *  Args:   ctx:        pointer to a context object
- *  In/Out: pubkey:     pointer to the public key to be negated (cannot be NULL)
- */
+/* {{{ proto int secp256k1_ec_pubkey_negate(resource ctx, resource pubkey)
+ * Negates a public key in place. */
 PHP_FUNCTION(secp256k1_ec_pubkey_negate)
 {
     zval *zCtx, *zPubKey;
@@ -857,15 +746,10 @@ PHP_FUNCTION(secp256k1_ec_pubkey_negate)
 
     RETURN_LONG(result);
 }
+/* }}} */
 
-/* Parse a variable length public key into a public key resource */
-/** {{{ proto int secp256k1_ec_pubkey_parse(resource secp256k1_context, string publicKey)
- *  In:    ctx:          a secp256k1_context resource
- *         pubkey:       an empty variable, set the public key resource here.
- *         publicKey:    a serialized public key
- *  Returns: 1:          a public key was set to pubkey.
-             anything else: error.
- */
+/* {{{ proto int secp256k1_ec_pubkey_parse(resource secp256k1_context, resource &pubKey, string pubKeyIn)
+ * Parse a variable-length public key into the pubkey object. */
 PHP_FUNCTION(secp256k1_ec_pubkey_parse)
 {
     zval *zCtx, *zPubKey;
@@ -895,6 +779,8 @@ PHP_FUNCTION(secp256k1_ec_pubkey_parse)
 }
 /* }}} */
 
+/* {{{ proto int secp256k1_ec_pubkey_serialize(resource context, string &pubKeyOut, resource pubKey, bool compressed)
+ * Serialize a pubkey object into a serialized byte sequence. */
 PHP_FUNCTION(secp256k1_ec_pubkey_serialize)
 {
     zval *zCtx, *zPubKey, *zPubOut;
@@ -931,6 +817,8 @@ PHP_FUNCTION(secp256k1_ec_pubkey_serialize)
 }
 /* }}} */
 
+/* {{{ proto int secp256k1_ec_privkey_tweak_add(resource context, string &key32, string tweak32)
+ * Tweak a private key by adding tweak to it. */
 PHP_FUNCTION(secp256k1_ec_privkey_tweak_add)
 {
     zval *zCtx, *zSecKey;
@@ -971,6 +859,8 @@ PHP_FUNCTION(secp256k1_ec_privkey_tweak_add)
 }
 /* }}} */
 
+/* {{{ proto int secp256k1_ec_pubkey_tweak_add(resource context, resource pubKey, string tweak32)
+ * Tweak a public key by adding tweak times the generator to it. */
 PHP_FUNCTION(secp256k1_ec_pubkey_tweak_add)
 {
     zval *zCtx, *zPubKey;
@@ -1001,6 +891,8 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_add)
 }
 /* }}} */
 
+/* {{{ proto int secp256k1_ec_privkey_tweak_mul(resource context, string &key32, string tweak32)
+ * Tweak a private key by multiplying it by a tweak. */
 PHP_FUNCTION(secp256k1_ec_privkey_tweak_mul)
 {
     zval *zCtx, *zSecKey;
@@ -1042,6 +934,8 @@ PHP_FUNCTION(secp256k1_ec_privkey_tweak_mul)
 }
 /* }}} */
 
+/* {{{ proto int secp256k1_ec_pubkey_tweak_mul(resource context, resource pubKey, string tweak32)
+ * Tweak a public key by multiplying it by a tweak value. */
 PHP_FUNCTION(secp256k1_ec_pubkey_tweak_mul)
 {
     zval *zCtx, *zPubKey;
@@ -1052,7 +946,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_mul)
     zend_string *tweak;
     int result;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/S", &zCtx, &zPubKey, &tweak) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rrS", &zCtx, &zPubKey, &tweak) == FAILURE) {
         RETURN_FALSE;
     }
 
@@ -1069,223 +963,8 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_mul)
 }
 /* }}} */
 
-/* Begin recovery module functions */
-
-PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_parse_compact)
-{
-    zval *zCtx, *zSig;
-    secp256k1_context *ctx;
-    secp256k1_ecdsa_recoverable_signature *sig;
-    zend_string *input64;
-    long recid;
-    int result;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/Sl", &zCtx, &zSig, &input64, &recid) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if (input64->len != 64) {
-        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_recoverable_signature_parse_compact(): Parameter 3 should be 64 bytes");
-        return;
-    }
-
-    if (!(recid >= 0 && recid <= 3)) {
-        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_recoverable_signature_parse_compact(): recid should be between 0-3");
-        return;
-    }
-
-    sig = emalloc(sizeof(secp256k1_ecdsa_recoverable_signature));
-    result = secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, sig, input64->val, recid);
-    if (result == 1) {
-        ZVAL_RES(zSig, zend_register_resource(sig, le_secp256k1_recoverable_sig));
-    } else {
-        efree(sig);
-    }
-
-    RETURN_LONG(result);
-}
-/* }}} */
-
-PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_convert)
-{
-    zval *zCtx, *zNormalSig, *zRecoverableSig;
-    secp256k1_context *ctx;
-    secp256k1_ecdsa_signature * nSig;
-    secp256k1_ecdsa_recoverable_signature * rSig;
-    int result;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/r", &zCtx, &zNormalSig, &zRecoverableSig) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if ((rSig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zRecoverableSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    nSig = emalloc(sizeof(secp256k1_ecdsa_recoverable_signature));
-    result = secp256k1_ecdsa_recoverable_signature_convert(ctx, nSig, rSig);
-    if (result) {
-        ZVAL_RES(zNormalSig, zend_register_resource(nSig, le_secp256k1_sig));
-    } else {
-        efree(nSig);
-    }
-
-    RETURN_LONG(result);
-}
-/* }}} */
-
-PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
-{
-    zval *zCtx, *zRecSig, *zSigOut, *zRecId;
-    secp256k1_context *ctx;
-    secp256k1_ecdsa_recoverable_signature *recsig;
-    unsigned char *sig;
-    int result, recid;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rrz/z/", &zCtx, &zRecSig, &zSigOut, &zRecId) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if ((recsig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zRecSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    sig = emalloc(COMPACT_SIGNATURE_LENGTH);
-    result = secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, recsig);
-    if (result == 1) {
-        ZVAL_STRINGL(zSigOut, sig, COMPACT_SIGNATURE_LENGTH);
-        ZVAL_LONG(zRecId, recid);
-    } else {
-        efree(sig);
-    }
-
-    RETURN_LONG(result);
-}
-/* }}} */
-
-PHP_FUNCTION(secp256k1_ecdsa_sign_recoverable)
-{
-    zval *zCtx, *zSig;
-    secp256k1_context *ctx;
-    zend_string *msg32, *seckey;
-    secp256k1_ecdsa_recoverable_signature *newsig;
-    int result;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/SS", &zCtx, &zSig, &msg32, &seckey) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if (msg32->len != HASH_LENGTH) {
-        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_sign_recoverable(): Parameter 2 should be 32 bytes");
-        return;
-    }
-
-    if (seckey->len != SECRETKEY_LENGTH) {
-        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_sign_recoverable(): Parameter 3 should be 32 bytes");
-        return;
-    }
-
-    newsig = emalloc(sizeof(secp256k1_ecdsa_recoverable_signature));
-    result = secp256k1_ecdsa_sign_recoverable(ctx, newsig, msg32->val, seckey->val, 0, 0);
-    if (result == 1) {
-        ZVAL_RES(zSig, zend_register_resource(newsig, le_secp256k1_recoverable_sig));
-    } else {
-        efree(newsig);
-    }
-
-    RETURN_LONG(result);
-}
-/* }}} */
-
-/** Recover an ECDSA public key from a signature.
- * {{{ proto int secp256k1_ecdsa_recover(secp256k1_context, msg32, secp256k1_recoverable_signature, secp256k1_pubkey)
- *  Returns: 1: public key successfully recovered (which guarantees a correct signature).
- *           0: otherwise.
- *  In:      secp256k1_context:                pointer to a context object, initialized for verification (cannot be NULL)
- *           msg32:                              the 32-byte message hash assumed to be signed (cannot be NULL)
- *           secp256k1_recoverable_signature:  pointer to initialized signature that supports pubkey recovery (cannot be NULL)
- *  Out:     secp256k1_ec_pubkey:              pointer to the recovered secp256k1_pubkey resource (cannot be NULL)
- */
-PHP_FUNCTION(secp256k1_ecdsa_recover)
-{
-    zval *zCtx, *zPubKey, *zSig;
-    secp256k1_context *ctx;
-    secp256k1_pubkey *pubkey;
-    secp256k1_ecdsa_recoverable_signature *sig;
-    zend_string *msg32;
-    int result;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS", &zCtx, &zPubKey, &zSig, &msg32) == FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, 0)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if ((sig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, 0)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    pubkey = (secp256k1_pubkey *) emalloc(sizeof(secp256k1_pubkey));
-    result = secp256k1_ecdsa_recover(ctx, pubkey, sig, msg32->val);
-    if (result) {
-        ZVAL_RES(zPubKey, zend_register_resource(pubkey, le_secp256k1_pubkey));
-    } else {
-        efree(pubkey);
-    }
-
-    RETURN_LONG(result);
-}
-/* }}} */
-
-PHP_FUNCTION(secp256k1_ecdh)
-{
-    zval *zCtx, *zResult, *zPubKey;
-    secp256k1_context *ctx;
-    secp256k1_pubkey *pubkey;
-    zend_string *privKey;
-    int result;
-
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS", &zCtx, &zResult, &zPubKey, &privKey)== FAILURE) {
-        RETURN_FALSE;
-    }
-
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
-        RETURN_FALSE;
-    }
-
-    unsigned char resultChars[32];
-    memset(resultChars, 0, 32);
-    result = secp256k1_ecdh(ctx, resultChars, pubkey, privKey->val);
-    if (result == 1) {
-        zval_dtor(zResult);
-        ZVAL_STRINGL(zResult, resultChars, 32);
-    }
-
-    RETURN_LONG(result);
-}
-
+/* {{{ proto int secp256k1_ec_pubkey_combine(resource context, resource &pubKey, resource[] vPubKey)
+ * Add a number of public keys together. */
 PHP_FUNCTION(secp256k1_ec_pubkey_combine)
 {
     zval *arr, *zCtx, *zPubkeyCombined, *arrayPubKey;
@@ -1328,7 +1007,235 @@ PHP_FUNCTION(secp256k1_ec_pubkey_combine)
 
     RETURN_LONG(result);
 }
+/* }}} */
 
+/* Begin recovery module functions */
+
+/* {{{ proto int secp256k1_ecdsa_recoverable_signature_parse_compact(resource context, resource &sig, string sig64, int recid)
+ * Parse a compact ECDSA signature (64 bytes + recovery id). */
+PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_parse_compact)
+{
+    zval *zCtx, *zSig;
+    secp256k1_context *ctx;
+    secp256k1_ecdsa_recoverable_signature *sig;
+    zend_string *input64;
+    long recid;
+    int result;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/Sl", &zCtx, &zSig, &input64, &recid) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if (input64->len != 64) {
+        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_recoverable_signature_parse_compact(): Parameter 3 should be 64 bytes");
+        return;
+    }
+
+    if (!(recid >= 0 && recid <= 3)) {
+        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_recoverable_signature_parse_compact(): recid should be between 0-3");
+        return;
+    }
+
+    sig = emalloc(sizeof(secp256k1_ecdsa_recoverable_signature));
+    result = secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, sig, input64->val, recid);
+    if (result == 1) {
+        ZVAL_RES(zSig, zend_register_resource(sig, le_secp256k1_recoverable_sig));
+    } else {
+        efree(sig);
+    }
+
+    RETURN_LONG(result);
+}
+/* }}} */
+
+/* {{{ proto int secp256k1_ecdsa_recoverable_signature_convert(resource context, resource &normalSigOut, resource sigIn)
+ * Convert a recoverable signature into a normal signature. */
+PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_convert)
+{
+    zval *zCtx, *zNormalSig, *zRecoverableSig;
+    secp256k1_context *ctx;
+    secp256k1_ecdsa_signature * nSig;
+    secp256k1_ecdsa_recoverable_signature * rSig;
+    int result;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/r", &zCtx, &zNormalSig, &zRecoverableSig) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if ((rSig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zRecoverableSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    nSig = emalloc(sizeof(secp256k1_ecdsa_recoverable_signature));
+    result = secp256k1_ecdsa_recoverable_signature_convert(ctx, nSig, rSig);
+    if (result) {
+        zval_dtor(zNormalSig);
+        ZVAL_RES(zNormalSig, zend_register_resource(nSig, le_secp256k1_sig));
+    } else {
+        efree(nSig);
+    }
+
+    RETURN_LONG(result);
+}
+/* }}} */
+
+/* {{{ proto int secp256k1_ecdsa_recoverable_signature_serialize_compact(resource context, resource sig, string &sigOut, int &recid)
+ * Serialize an ECDSA signature in compact format (64 bytes + recovery id). */
+PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
+{
+    zval *zCtx, *zRecSig, *zSigOut, *zRecId;
+    secp256k1_context *ctx;
+    secp256k1_ecdsa_recoverable_signature *recsig;
+    unsigned char *sig;
+    int result, recid;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rrz/z/", &zCtx, &zRecSig, &zSigOut, &zRecId) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if ((recsig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zRecSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    sig = emalloc(COMPACT_SIGNATURE_LENGTH);
+    result = secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, recsig);
+    if (result == 1) {
+        ZVAL_STRINGL(zSigOut, sig, COMPACT_SIGNATURE_LENGTH);
+        ZVAL_LONG(zRecId, recid);
+    } else {
+        efree(sig);
+    }
+
+    RETURN_LONG(result);
+}
+/* }}} */
+
+/* {{{ proto int secp256k1_ecdsa_sign_recoverable(resource context, resource &sig, string msg32, string key32)
+ * Create a recoverable ECDSA signature. */
+PHP_FUNCTION(secp256k1_ecdsa_sign_recoverable)
+{
+    zval *zCtx, *zSig;
+    secp256k1_context *ctx;
+    zend_string *msg32, *seckey;
+    secp256k1_ecdsa_recoverable_signature *newsig;
+    int result;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/SS", &zCtx, &zSig, &msg32, &seckey) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if (msg32->len != HASH_LENGTH) {
+        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_sign_recoverable(): Parameter 2 should be 32 bytes");
+        return;
+    }
+
+    if (seckey->len != SECRETKEY_LENGTH) {
+        zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "secp256k1_ecdsa_sign_recoverable(): Parameter 3 should be 32 bytes");
+        return;
+    }
+
+    newsig = emalloc(sizeof(secp256k1_ecdsa_recoverable_signature));
+    result = secp256k1_ecdsa_sign_recoverable(ctx, newsig, msg32->val, seckey->val, 0, 0);
+    if (result == 1) {
+        ZVAL_RES(zSig, zend_register_resource(newsig, le_secp256k1_recoverable_sig));
+    } else {
+        efree(newsig);
+    }
+
+    RETURN_LONG(result);
+}
+/* }}} */
+
+/* {{{ proto int secp256k1_ecdsa_recover(resource context, resource &pubKey, resource recSig, string msg32)
+ * Recover an ECDSA public key from a signature. */
+PHP_FUNCTION(secp256k1_ecdsa_recover)
+{
+    zval *zCtx, *zPubKey, *zSig;
+    secp256k1_context *ctx;
+    secp256k1_pubkey *pubkey;
+    secp256k1_ecdsa_recoverable_signature *sig;
+    zend_string *msg32;
+    int result;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS", &zCtx, &zPubKey, &zSig, &msg32) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, 0)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if ((sig = (secp256k1_ecdsa_recoverable_signature *)zend_fetch_resource2_ex(zSig, SECP256K1_RECOVERABLE_SIG_RES_NAME, le_secp256k1_recoverable_sig, 0)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    pubkey = (secp256k1_pubkey *) emalloc(sizeof(secp256k1_pubkey));
+    result = secp256k1_ecdsa_recover(ctx, pubkey, sig, msg32->val);
+    if (result) {
+        ZVAL_RES(zPubKey, zend_register_resource(pubkey, le_secp256k1_pubkey));
+    } else {
+        efree(pubkey);
+    }
+
+    RETURN_LONG(result);
+}
+/* }}} */
+
+/* End recovery module functions */
+
+/* Begin EcDH module functions */
+
+/* {{{ proto int secp256k1_ecdh(resource context, string &result, resource pubKey, string key32)
+ * Compute an EC Diffie-Hellman secret in constant time. */
+PHP_FUNCTION(secp256k1_ecdh)
+{
+    zval *zCtx, *zResult, *zPubKey;
+    secp256k1_context *ctx;
+    secp256k1_pubkey *pubkey;
+    zend_string *privKey;
+    int result;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS", &zCtx, &zResult, &zPubKey, &privKey)== FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    if ((pubkey = (secp256k1_pubkey *)zend_fetch_resource2_ex(zPubKey, SECP256K1_PUBKEY_RES_NAME, le_secp256k1_pubkey, -1)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    unsigned char resultChars[32];
+    memset(resultChars, 0, 32);
+    result = secp256k1_ecdh(ctx, resultChars, pubkey, privKey->val);
+    if (result == 1) {
+        zval_dtor(zResult);
+        ZVAL_STRINGL(zResult, resultChars, 32);
+    }
+
+    RETURN_LONG(result);
+}
+/* }}} */
+
+/* End EcDH module functions */
 
 /*
  * Local variables:

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -256,9 +256,14 @@ static void secp256k1_recoverable_sig_dtor(zend_resource * rsrc TSRMLS_DC)
     }
 }
 
-// attempt to read a sec256k1_context* from the provided resource
+// attempt to read a sec256k1_context* from the provided resource zval
 static secp256k1_context* php_get_secp256k1_context(zval* pcontext) {
     return (secp256k1_context *)zend_fetch_resource2_ex(pcontext, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1);
+}
+
+// attempt to read a sec256k1_ecdsa_signature* from the provided resource zval
+static secp256k1_ecdsa_signature* php_get_secp256k1_ecdsa_signature(zval *psig) {
+    return (secp256k1_ecdsa_signature *)zend_fetch_resource2_ex(psig, SECP256K1_SIG_RES_NAME, le_secp256k1_sig, -1);
 }
 
 PHP_MINIT_FUNCTION(secp256k1) {
@@ -435,7 +440,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_der)
         RETURN_FALSE;
     }
 
-    if ((sig = (secp256k1_ecdsa_signature *)zend_fetch_resource2_ex(zSig, SECP256K1_SIG_RES_NAME, le_secp256k1_sig, -1)) == NULL) {
+    if ((sig = php_get_secp256k1_ecdsa_signature(zSig)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -529,7 +534,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
         RETURN_FALSE;
     }
 
-    if ((sigin = (secp256k1_ecdsa_signature *)zend_fetch_resource2_ex(zSigIn, SECP256K1_SIG_RES_NAME, le_secp256k1_sig, -1)) == NULL) {
+    if ((sigin = php_get_secp256k1_ecdsa_signature(zSigIn)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -563,7 +568,7 @@ PHP_FUNCTION(secp256k1_ecdsa_verify) {
         RETURN_FALSE;
     }
 
-    if ((sig = (secp256k1_ecdsa_signature *)zend_fetch_resource2_ex(zSig, SECP256K1_SIG_RES_NAME, le_secp256k1_sig, -1)) == NULL) {
+    if ((sig = php_get_secp256k1_ecdsa_signature(zSig)) == NULL) {
         RETURN_FALSE;
     }
 

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -342,12 +342,12 @@ PHP_FUNCTION(secp256k1_context_create)
 PHP_FUNCTION(secp256k1_context_destroy)
 {
     zval *zCtx;
+    secp256k1_context *ctx;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zCtx) == FAILURE) {
         RETURN_FALSE;
     }
 
-    secp256k1_context *ctx;
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1031,7 +1031,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_parse_compact)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1071,7 +1071,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_convert)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1106,7 +1106,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1141,7 +1141,7 @@ PHP_FUNCTION(secp256k1_ecdsa_sign_recoverable)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1182,7 +1182,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recover)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, 0)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 
@@ -1220,7 +1220,7 @@ PHP_FUNCTION(secp256k1_ecdh)
         RETURN_FALSE;
     }
 
-    if ((ctx = (secp256k1_context *)zend_fetch_resource2_ex(zCtx, SECP256K1_CTX_RES_NAME, le_secp256k1_ctx, -1)) == NULL) {
+    if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
         RETURN_FALSE;
     }
 


### PR DESCRIPTION
Cleans up the projects documentation, making it consistent with other extensions. Extracted some of the functions for retrieving a resource value from a zval, some instances had different constants etc so this seems better..