### PR TITLE
Travis test improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,15 @@ before_install:
 
 install:
   - |
-      git clone https://github.com/bitcoin-core/secp256k1.git libsecp256k1 \
-      && cd libsecp256k1 && git checkout $SECP256K1_COMMIT \
-      && ./autogen.sh && ./configure --enable-benchmark=no --enable-experimental --enable-module-{ecdh,recovery} && make && sudo make install \
-      && cd ..
+      git clone https://github.com/bitcoin-core/secp256k1.git libsecp256k1        \
+      && cd libsecp256k1 && git checkout $SECP256K1_COMMIT                        \
+      && ./autogen.sh                                                             \
+      && ./configure --enable-tests=no --enable-benchmark=no                      \
+             --enable-experimental --enable-module-{ecdh,recovery}                \
+      && make -j$(nproc) && sudo make install && cd ..
   - |
-      cd secp256k1 \
-      && phpize && ./configure && make && sudo make install \
+      cd secp256k1 && phpize                                                      \
+      && ./configure && make -j$(nproc) && sudo make install                      \
       && cd ..
   - composer update
 
@@ -49,10 +51,6 @@ before_script:
       fi
 
 script:
-  - |
-      cd libsecp256k1 \
-      && ./tests || exit 1 \
-      && cd ..
   - cd secp256k1/ && REPORT_EXIT_STATUS=1 make test || exit 1 && cd ..
   - php -dextension=secp256k1.so vendor/phpunit/phpunit/phpunit tests/ || exit 1
   - cd travis && ./run_coverage_test.sh || exit 1 && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 
 env:
   global:
+   - SECP256K1_COMMIT=cd329dbc3eaf096ae007e807b86b6f5947621ee3
    - DOCKER_CACHE_DIR=/home/travis/docker
 
 cache:
@@ -22,7 +23,7 @@ matrix:
 
   include:
     - php: 7.0
-      env: COVERAGE_TARGET=95 COVERAGE=true SECP256K1_COMMIT=cd329dbc3eaf096ae007e807b86b6f5947621ee3 COVERAGE_PREFIX_FUNCTIONS=zif_,zm_,secp256k1_
+      env: COVERAGE_TARGET=95 COVERAGE=true COVERAGE_PREFIX_FUNCTIONS=zif_,zm_,secp256k1_
 
 before_install:
   - sudo apt-get install -qq libssl-dev
@@ -30,9 +31,9 @@ before_install:
 
 install:
   - |
-      git clone git://github.com/bitcoin/secp256k1.git libsecp256k1 \
-      && cd libsecp256k1 \
-      && ./autogen.sh && ./configure --enable-experimental --enable-module-{ecdh,recovery} && make && sudo make install \
+      git clone https://github.com/bitcoin-core/secp256k1.git libsecp256k1 \
+      && cd libsecp256k1 && git checkout $SECP256K1_COMMIT \
+      && ./autogen.sh && ./configure --enable-benchmark=no --enable-experimental --enable-module-{ecdh,recovery} && make && sudo make install \
       && cd ..
   - |
       cd secp256k1 \

--- a/travis/phpqa/Dockerfile
+++ b/travis/phpqa/Dockerfile
@@ -144,7 +144,7 @@ RUN cd /usr/src/php/scripts/dev \
 RUN cd / && git clone https://github.com/bitcoin-core/secp256k1.git \
     && cd secp256k1 && git checkout $SECP256K1_COMMIT \
     && ./autogen.sh \
-    && ./configure --enable-experimental --enable-module-ecdh --enable-module-recovery \
+    && ./configure --enable-benchmark=no --enable-tests=no --enable-experimental --enable-module-ecdh --enable-module-recovery \
     && make && make install && ldconfig
 
 ADD scripts/coverage.sh /usr/bin


### PR DESCRIPTION
SECP256K1_COMMIT was only set on coverage builds, but this PR makes it available in all builds so they can build the same commit. We also disable building benchmarks and tests of libsecp256k1, we assume it works..