### PR TITLE
fix api for secp256k1_ecdsa_recoverable_signature_serialize_compact

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -265,9 +265,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(arginfo_secp256k1_ecdsa_recoverable_signatu
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(arginfo_secp256k1_ecdsa_recoverable_signature_serialize_compact, IS_LONG, 0)
 #endif
     ZEND_ARG_TYPE_INFO(0, context, IS_RESOURCE, 0)
-    ZEND_ARG_TYPE_INFO(0, ecdsaRecoverableSignature, IS_RESOURCE, 0)
     ZEND_ARG_TYPE_INFO(1, sig64Out, IS_STRING, 1)
     ZEND_ARG_TYPE_INFO(1, recIdOut, IS_LONG, 1)
+    ZEND_ARG_TYPE_INFO(0, ecdsaRecoverableSignature, IS_RESOURCE, 0)
 ZEND_END_ARG_INFO();
 
 #if (PHP_VERSION_ID >= 70000 && PHP_VERSION_ID <= 70200)
@@ -1310,7 +1310,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_convert)
 }
 /* }}} */
 
-/* {{{ proto int secp256k1_ecdsa_recoverable_signature_serialize_compact(resource context, resource sig, string &sigOut, int &recid)
+/* {{{ proto int secp256k1_ecdsa_recoverable_signature_serialize_compact(resource context, string &sigOut, int &recid, resource sig)
  * Serialize an ECDSA signature in compact format (64 bytes + recovery id). */
 PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
 {
@@ -1320,8 +1320,8 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
     unsigned char *sig;
     int result = 0, recid;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rrz/z/", &zCtx, &zRecSig, &zSigOut, &zRecId) == FAILURE) {
-        RETURN_LONG(result);
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/z/r", &zCtx, &zSigOut, &zRecId, &zRecSig) == FAILURE) {
+        RETURN_FALSE;
     }
 
     if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {

--- a/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_basic.phpt
+++ b/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_basic.phpt
@@ -18,7 +18,7 @@ $result = secp256k1_ecdsa_recoverable_signature_parse_compact($context, $signatu
 echo $result . PHP_EOL;
 
 $sigOut = '';
-$result = secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $signature, $sigOut, $recid);
+$result = secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $sigOut, $recid, $signature);
 echo $result . PHP_EOL;
 echo unpack("H*", $sigOut)[1] . PHP_EOL;
 

--- a/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_error1.phpt
+++ b/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_error1.phpt
@@ -10,9 +10,8 @@ if (!extension_loaded("secp256k1")) print "skip extension not loaded";
 set_error_handler(function($code, $str) { echo $str . PHP_EOL; });
 
 $result = secp256k1_ecdsa_recoverable_signature_serialize_compact();
-echo $result . PHP_EOL;
-
+echo ($result ? "true" : "false") . PHP_EOL;
 ?>
 --EXPECT--
 secp256k1_ecdsa_recoverable_signature_serialize_compact() expects exactly 4 parameters, 0 given
-0
+false

--- a/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_error2.phpt
+++ b/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_error2.phpt
@@ -17,7 +17,7 @@ $sigIn = pack("H*", 'fe5fe404f3d8c21e1204a08c38ff3912d43c5a22541d2f1cdc4977cbcad
 $signature = tmpfile();
 
 $sigOut = '';
-$result = secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $signature, $sigOut, $recid);
+$result = secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $sigOut, $recid, $signature);
 echo $result . PHP_EOL;
 
 ?>

--- a/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_error3.phpt
+++ b/secp256k1/tests/secp256k1_ecdsa_recoverable_signature_serialize_compact_error3.phpt
@@ -21,7 +21,7 @@ echo $result . PHP_EOL;
 
 $ctxBad = tmpfile();
 $sigOut = '';
-$result = secp256k1_ecdsa_recoverable_signature_serialize_compact($ctxBad, $signature, $sigOut, $recid);
+$result = secp256k1_ecdsa_recoverable_signature_serialize_compact($ctxBad, $sigOut, $recid, $signature);
 echo $result . PHP_EOL;
 
 ?>

--- a/stubs/Secp256k1Stubs.php
+++ b/stubs/Secp256k1Stubs.php
@@ -161,7 +161,7 @@ namespace {
      * @param int $recid
      * @return int
      */
-    function secp256k1_ecdsa_recoverable_signature_serialize_compact($secp256k1_context, $secp256k1_ecdsa_recoverable_signature, $signatureOut, $recid)
+    function secp256k1_ecdsa_recoverable_signature_serialize_compact($secp256k1_context, $signatureOut, $recid, $secp256k1_ecdsa_recoverable_signature)
     {
     }
 

--- a/tests/Secp256k1SignRecoverableTest.php
+++ b/tests/Secp256k1SignRecoverableTest.php
@@ -37,7 +37,7 @@ class Secp256k1SignRecoverableTest extends TestCase
         $sSig = '';
         /** @var resource $sSig */
         $recid = 0;
-        secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $r_sig_t, $sSig, $recid);
+        secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $sSig, $recid, $r_sig_t);
 
         $parsedSig = null;
         /** @var resource $parsedSig */
@@ -45,7 +45,7 @@ class Secp256k1SignRecoverableTest extends TestCase
 
         $sSigAgain = '';
         $recidAgain = 0;
-        secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $parsedSig, $sSigAgain, $recidAgain);
+        secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $sSigAgain, $recidAgain, $parsedSig);
 
 
         // Prepare expected DER sig


### PR DESCRIPTION
This fixes the parameter order for secp256k1_ecdsa_recoverable_signature_serialize_compact. This is a BC break, so should be kept out of v0.1.x

Issue: #93 