### PR TITLE
Fix secp256k1_ec_pubkey_serialize API

### DIFF
--- a/examples/compress_public_key.php
+++ b/examples/compress_public_key.php
@@ -10,7 +10,8 @@ if (1 !== secp256k1_ec_pubkey_parse($context, $publicKey, $publicKeyBin)) {
 }
 
 $compressed = '';
-if (1 !== secp256k1_ec_pubkey_serialize($context, $compressed, $publicKey, true /* whether to compress */)) {
+$serializeFlags = SECP256K1_EC_COMPRESSED;
+if (1 !== secp256k1_ec_pubkey_serialize($context, $compressed, $publicKey, $serializeFlags)) {
     throw new \RuntimeException("Failed to serialize key");
 }
 

--- a/examples/create_public_key.php
+++ b/examples/create_public_key.php
@@ -9,10 +9,10 @@ $privateKey = pack("H*", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 $publicKey = null;
 $result = secp256k1_ec_pubkey_create($context, $publicKey, $privateKey);
 if ($result === 1) {
-    $compress = true;
+    $serializeFlags = SECP256K1_EC_COMPRESSED;
 
     $serialized = '';
-    if (1 !== secp256k1_ec_pubkey_serialize($context, $serialized, $publicKey, $compress)) {
+    if (1 !== secp256k1_ec_pubkey_serialize($context, $serialized, $publicKey, $serializeFlags)) {
         throw new \Exception('secp256k1_ec_pubkey_serialize: failed to serialize public key');
     }
 

--- a/examples/decompress_public_key.php
+++ b/examples/decompress_public_key.php
@@ -10,7 +10,8 @@ if (1 !== secp256k1_ec_pubkey_parse($context, $publicKey, $publicKeyBin)) {
 }
 
 $decompressed = '';
-if (1 !== secp256k1_ec_pubkey_serialize($context, $decompressed, $publicKey, false /* whether to compress */)) {
+$serializeFlags = SECP256K1_EC_UNCOMPRESSED;
+if (1 !== secp256k1_ec_pubkey_serialize($context, $decompressed, $publicKey, $serializeFlags)) {
     throw new \RuntimeException("Failed to serialize key");
 }
 

--- a/examples/pubkey_tweak_by_addition.php
+++ b/examples/pubkey_tweak_by_addition.php
@@ -12,7 +12,7 @@ $tweak = pack("H*", "00000000000000000000000000000000000000000000000000000000000
 $result = secp256k1_ec_pubkey_tweak_add($context, $publicKey, $tweak);
 if ($result == 1) {
     $pubKeyOut = '';
-    secp256k1_ec_pubkey_serialize($context, $pubKeyOut, $publicKey, 1);
+    secp256k1_ec_pubkey_serialize($context, $pubKeyOut, $publicKey, SECP256K1_EC_COMPRESSED);
     echo sprintf("Tweaked public key: %s\n", unpack("H*", $pubKeyOut)[1]);
 } else {
     throw new \Exception("Invalid public key or augend value");

--- a/examples/pubkey_tweak_by_multiplication.php
+++ b/examples/pubkey_tweak_by_multiplication.php
@@ -15,7 +15,8 @@ if (1 !== secp256k1_ec_pubkey_parse($context, $publicKey, $publicKeyBin)) {
 $result = secp256k1_ec_pubkey_tweak_mul($context, $publicKey, $tweak);
 if ($result == 1) {
     $serialized = '';
-    secp256k1_ec_pubkey_serialize($context, $serialized, $publicKey, $compressed);
+    $flags = $compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+    secp256k1_ec_pubkey_serialize($context, $serialized, $publicKey, $flags);
     echo sprintf("Tweaked public key: %s\n", unpack("H*", $serialized)[1]);
 } else {
     throw new \Exception("Invalid public key or multiplicand value");

--- a/secp256k1/tests/secp256k1_ec_pubkey_combine_basic.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_combine_basic.phpt
@@ -16,7 +16,7 @@ $pubKeyOut2 = '';
 $result = secp256k1_ec_pubkey_create($ctx, $pubKey, $seckey);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut1, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut1, $pubKey, SECP256K1_EC_COMPRESSED);
 echo unpack("H*", $pubKeyOut1)[1] . PHP_EOL;
 
 $pubKeys = [$pubKey];
@@ -25,7 +25,7 @@ $combinedPubKey = null;
 $result = secp256k1_ec_pubkey_combine($ctx, $combinedPubKey, $pubKeys);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut2, $combinedPubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut2, $combinedPubKey, SECP256K1_EC_COMPRESSED);
 echo unpack("H*", $pubKeyOut2)[1] . PHP_EOL;
 
 ?>

--- a/secp256k1/tests/secp256k1_ec_pubkey_create_basic.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_create_basic.phpt
@@ -13,14 +13,14 @@ $result = secp256k1_ec_pubkey_create($ctx, $pubKey, $seckey);
 echo $result . PHP_EOL;
 
 $pubKeyCompressed1 = '';
-$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyCompressed1, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
-echo unpack("H*", $pubKeyOut)[1] . PHP_EOL;
+echo unpack("H*", $pubKeyCompressed1)[1] . PHP_EOL;
 
 $pubKeyUncompressed1 = '';
-$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut, $pubKey, 0);
+$result = secp256k1_ec_pubkey_serialize($ctx, $pubKeyUncompressed1, $pubKey, SECP256K1_EC_UNCOMPRESSED);
 echo $result . PHP_EOL;
-echo unpack("H*", $pubKeyOut)[1] . PHP_EOL;
+echo unpack("H*", $pubKeyUncompressed1)[1] . PHP_EOL;
 
 ?>
 --EXPECT--

--- a/secp256k1/tests/secp256k1_ec_pubkey_encoding_basic.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_encoding_basic.phpt
@@ -16,7 +16,7 @@ echo $result . PHP_EOL;
 echo get_resource_type($pubKey) . PHP_EOL;
 
 $pubKeySer = null;
-$result = \secp256k1_ec_pubkey_serialize($context, $pubKeySer, $pubKey, 1);
+$result = \secp256k1_ec_pubkey_serialize($context, $pubKeySer, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;;
 echo bin2hex($pubKeySer) . PHP_EOL;
 ?>

--- a/secp256k1/tests/secp256k1_ec_pubkey_negate_basic.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_negate_basic.phpt
@@ -14,21 +14,21 @@ $pubKeyOut = '';
 $pubKey = null;
 $result = \secp256k1_ec_pubkey_parse($ctx, $pubKey, $pubKeyIn);
 
-$result = \secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut, $pubKey, 1);
+$result = \secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut, $pubKey, SECP256K1_EC_COMPRESSED);
 echo unpack("H*", $pubKeyOut)[1] . PHP_EOL;
 
 $result = \secp256k1_ec_pubkey_negate($ctx, $pubKey);
 echo $result . PHP_EOL;
 
 $pubKeySer = null;
-$result = \secp256k1_ec_pubkey_serialize($ctx, $pubKeySer, $pubKey, 1);
+$result = \secp256k1_ec_pubkey_serialize($ctx, $pubKeySer, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo bin2hex($pubKeySer) . PHP_EOL;
 
 $result = \secp256k1_ec_pubkey_negate($ctx, $pubKey);
 echo $result . PHP_EOL;
 
-$result = \secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut, $pubKey, 1);
+$result = \secp256k1_ec_pubkey_serialize($ctx, $pubKeyOut, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $pubKeyOut)[1] . PHP_EOL;
 

--- a/secp256k1/tests/secp256k1_ec_pubkey_serialize_error1.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_serialize_error1.phpt
@@ -10,9 +10,9 @@ if (!extension_loaded("secp256k1")) print "skip extension not loaded";
 set_error_handler(function($code, $str) { echo $str . PHP_EOL; });
 
 $result = secp256k1_ec_pubkey_serialize();
-echo $result . PHP_EOL;
+echo ($result ? "true" : "false"). PHP_EOL;
 
 ?>
 --EXPECT--
 secp256k1_ec_pubkey_serialize() expects exactly 4 parameters, 0 given
-0
+false

--- a/secp256k1/tests/secp256k1_ec_pubkey_serialize_error2.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_serialize_error2.phpt
@@ -17,11 +17,13 @@ $result = \secp256k1_ec_pubkey_parse($context, $pub, $pubIn);
 $contextBad = \tmpfile();
 
 $pubKeyOut = '';
-$result = \secp256k1_ec_pubkey_serialize($contextBad, $pubKeyOut, $pub, 1);
+$result = \secp256k1_ec_pubkey_serialize($contextBad, $pubKeyOut, $pub, SECP256K1_EC_COMPRESSED);
+echo \gettype($result) . PHP_EOL;
 echo $result . PHP_EOL;
 
 ?>
 
 --EXPECT--
 secp256k1_ec_pubkey_serialize(): supplied resource is not a valid secp256k1_context resource
+integer
 0

--- a/secp256k1/tests/secp256k1_ec_pubkey_serialize_error3.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_serialize_error3.phpt
@@ -12,11 +12,13 @@ if (!extension_loaded("secp256k1")) print "skip extension not loaded";
 $context = \secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 $pubKeyOut = '';
 $pub = tmpfile();
-$result = \secp256k1_ec_pubkey_serialize($context, $pubKeyOut, $pub, 1);
+$result = \secp256k1_ec_pubkey_serialize($context, $pubKeyOut, $pub, SECP256K1_EC_COMPRESSED);
+echo \gettype($result) . PHP_EOL;
 echo $result . PHP_EOL;
 
 ?>
 
 --EXPECT--
 secp256k1_ec_pubkey_serialize(): supplied resource is not a valid secp256k1_pubkey resource
+integer
 0

--- a/secp256k1/tests/secp256k1_ec_pubkey_tweak_add_basic.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_tweak_add_basic.phpt
@@ -32,14 +32,14 @@ $result = secp256k1_ec_pubkey_tweak_add($context, $pubKey, $secKeyOne);
 echo $result . PHP_EOL;
 // 4
 
-$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 
 $result = secp256k1_ec_pubkey_create($context, $cmpKey, $secKeyFour);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serCmp)[1] . PHP_EOL;
 ?>

--- a/secp256k1/tests/secp256k1_ec_pubkey_tweak_mul_basic.phpt
+++ b/secp256k1/tests/secp256k1_ec_pubkey_tweak_mul_basic.phpt
@@ -31,11 +31,11 @@ echo $result . PHP_EOL;
 $result = secp256k1_ec_pubkey_create($context, $cmpKey, $secKeyTwo);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 // 2
@@ -46,11 +46,11 @@ echo $result . PHP_EOL;
 $result = secp256k1_ec_pubkey_create($context, $cmpKey, $secKeyFour);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 // 4
@@ -61,11 +61,11 @@ echo $result . PHP_EOL;
 $result = secp256k1_ec_pubkey_create($context, $cmpKey, $secKeyEight);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 // 8
@@ -76,11 +76,11 @@ echo $result . PHP_EOL;
 $result = secp256k1_ec_pubkey_create($context, $cmpKey, $secKeySixteen);
 echo $result . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serKey, $pubKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 
-$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $serCmp, $cmpKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 echo unpack("H*", $serKey)[1] . PHP_EOL;
 // 16

--- a/secp256k1/tests/secp256k1_ecdsa_sign_verify_recoverable_basic.phpt
+++ b/secp256k1/tests/secp256k1_ecdsa_sign_verify_recoverable_basic.phpt
@@ -33,11 +33,11 @@ echo $result . PHP_EOL;
 
 // Compare the two public keys
 $sPubkey = null;
-$result = secp256k1_ec_pubkey_serialize($context, $sPubkey, $expectedPublicKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $sPubkey, $expectedPublicKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 
 $srPubkey = null;
-$result = secp256k1_ec_pubkey_serialize($context, $srPubkey, $recoveredPublicKey, 1);
+$result = secp256k1_ec_pubkey_serialize($context, $srPubkey, $recoveredPublicKey, SECP256K1_EC_COMPRESSED);
 echo $result . PHP_EOL;
 
 echo unpack("H*", $sPubkey)[1] . PHP_EOL;

--- a/stubs/Secp256k1Stubs.php
+++ b/stubs/Secp256k1Stubs.php
@@ -4,11 +4,13 @@ namespace {
 
     define('SECP256K1_CONTEXT_SIGN', 513);
     define('SECP256K1_CONTEXT_VERIFY', 257);
+    define('SECP256K1_CONTEXT_NONE', 257);
     define('SECP256K1_TYPE_CONTEXT', "secp256k1_context");
     define('SECP256K1_TYPE_PUBKEY', "secp256k1_pubkey");
     define('SECP256K1_TYPE_SIG', "secp256k1_ecdsa_signature");
     define('SECP256K1_TYPE_RECOVERABLE_SIG', "secp256k1_ecdsa_recoverable_signature");
     define('SECP256K1_EC_COMPRESSED', 258);
+    define('SECP256K1_EC_UNCOMPRESSED', 258);
 
     /**
      * Create a Secp256k1 context resource
@@ -249,10 +251,10 @@ namespace {
      * @param resource $secp256k1_context
      * @param resource $secp256k1_pubkey
      * @param string $pubkeyOut
-     * @param bool $compressed
+     * @param int $flags
      * @return int
      */
-    function secp256k1_ec_pubkey_serialize($secp256k1_context, $pubkeyOut, $secp256k1_pubkey, $compressed)
+    function secp256k1_ec_pubkey_serialize($secp256k1_context, $pubkeyOut, $secp256k1_pubkey, $flags)
     {
     }
 

--- a/tests/Secp256k1EcdsaRecoverCompactTest.php
+++ b/tests/Secp256k1EcdsaRecoverCompactTest.php
@@ -9,7 +9,7 @@ class Secp256k1EcdsaRecoverCompactTest extends TestCase
 
         $context = \secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
         $recid = 1;
-        $compressed = 0;
+        $flags = SECP256K1_EC_UNCOMPRESSED;
 
         $sig = pack("H*", 'fe5fe404f3d8c21e1204a08c38ff3912d43c5a22541d2f1cdc4977cbcad240015a3b6e9040f62cacf016df4fef9412091592e4908e5e3a7bd2a42a4d1be01951');
         /** @var resource $s */
@@ -22,7 +22,7 @@ class Secp256k1EcdsaRecoverCompactTest extends TestCase
         $this->assertEquals(1, secp256k1_ec_pubkey_create($context, $publicKey, $privateKey));
 
         $ePubKey = '';
-        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $ePubKey, $publicKey, $compressed));
+        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $ePubKey, $publicKey, $flags));
 
         $msg = pack("H*", '03acc83ba10066e791d51e8a8eb90ec325feea7251cb8f979996848fff551d13');
 
@@ -30,7 +30,7 @@ class Secp256k1EcdsaRecoverCompactTest extends TestCase
         $this->assertEquals(1, secp256k1_ecdsa_recover($context, $recPubKey, $s, $msg));
 
         $serPubKey = '';
-        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $serPubKey, $recPubKey, $compressed));
+        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $serPubKey, $recPubKey, $flags));
         $this->assertEquals($ePubKey, $serPubKey);
     }
 }

--- a/tests/Secp256k1PubkeyCreateTest.php
+++ b/tests/Secp256k1PubkeyCreateTest.php
@@ -51,7 +51,8 @@ class Secp256k1PubkeyCreateTest extends TestCase
         $this->assertEquals(SECP256K1_TYPE_PUBKEY, get_resource_type($pubkey));
 
         $serialized = '';
-        secp256k1_ec_pubkey_serialize($context, $serialized, $pubkey, $fcompressed);
+        $flags = $fcompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+        secp256k1_ec_pubkey_serialize($context, $serialized, $pubkey, $flags);
         $this->assertEquals($expectedKey, bin2hex($serialized));
         $this->assertEquals(($fcompressed ? 33 : 65), strlen($serialized));
     }

--- a/tests/Secp256k1PubkeyEncodingTest.php
+++ b/tests/Secp256k1PubkeyEncodingTest.php
@@ -36,12 +36,12 @@ class Secp256k1PubkeyEncodingTest extends TestCase
         $this->assertEquals(1, $result);
 
         $pkWrite = '';
-        $result = secp256k1_ec_pubkey_serialize($context, $pkWrite, $pkOut, true);
+        $result = secp256k1_ec_pubkey_serialize($context, $pkWrite, $pkOut, SECP256K1_EC_COMPRESSED);
         $this->assertEquals(1, $result);
         $this->assertEquals(hex2bin($expectedCompressed), $pkWrite);
 
         $pkWrite = '';
-        $result = secp256k1_ec_pubkey_serialize($context, $pkWrite, $pkOut, false);
+        $result = secp256k1_ec_pubkey_serialize($context, $pkWrite, $pkOut, SECP256K1_EC_UNCOMPRESSED);
         $this->assertEquals(1, $result);
         $this->assertEquals(hex2bin($expectedPubKey), $pkWrite);
     }

--- a/tests/Secp256k1PubkeyTweakAddTest.php
+++ b/tests/Secp256k1PubkeyTweakAddTest.php
@@ -65,8 +65,9 @@ class Secp256k1PubkeyTweakAddTest extends TestCase
         $result = secp256k1_ec_pubkey_tweak_add($context, $p, $tweak);
         $this->assertEquals($eAdd, $result);
 
-        $pSer = null;
-        secp256k1_ec_pubkey_serialize($context, $pSer, $p, $compressed);
+        $pSer = '';
+        $flags = $compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+        secp256k1_ec_pubkey_serialize($context, $pSer, $p, $flags);
         $this->assertEquals(bin2hex($pSer), $expectedPublicKey);
     }
 }

--- a/tests/Secp256k1PubkeyTweakMulTest.php
+++ b/tests/Secp256k1PubkeyTweakMulTest.php
@@ -63,8 +63,11 @@ class Secp256k1PubkeyTweakMulTest extends TestCase
         secp256k1_ec_pubkey_parse($context, $p, $publicKey);
         $result = secp256k1_ec_pubkey_tweak_mul($context, $p, $tweak);
         $this->assertEquals($eMul, $result);
-        $ser = null;
-        secp256k1_ec_pubkey_serialize($context, $ser, $p, $compressed);
+
+        $ser = '';
+        $flags = $compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+        secp256k1_ec_pubkey_serialize($context, $ser, $p, $flags);
+
         $this->assertEquals($expectedPublicKey, bin2hex($ser));
     }
 }

--- a/tests/Secp256k1SignRecoverableTest.php
+++ b/tests/Secp256k1SignRecoverableTest.php
@@ -29,8 +29,8 @@ class Secp256k1SignRecoverableTest extends TestCase
         // Compare the two public keys
         $sPubkey = '';
         $srPubkey = '';
-        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $sPubkey, $pub_t, 0));
-        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $srPubkey, $r_pubkey_t, 0));
+        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $sPubkey, $pub_t, SECP256K1_EC_UNCOMPRESSED));
+        $this->assertEquals(1, secp256k1_ec_pubkey_serialize($context, $srPubkey, $r_pubkey_t, SECP256K1_EC_UNCOMPRESSED));
         $this->assertEquals($sPubkey, $srPubkey);
 
         // Double check that serialize(sig) == serialize(parse(serialize(sig))


### PR DESCRIPTION
This function takes a flags parameter instead
of compressed boolean..