### PR TITLE
secp256k1_ecdsa_verify shouldn't normalize signatures by default

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -780,7 +780,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_normalize)
 PHP_FUNCTION(secp256k1_ecdsa_verify) {
     zval *zCtx, *zSig, *zPubKey;
     secp256k1_context *ctx;
-    secp256k1_ecdsa_signature *sig, *sigcpy;
+    secp256k1_ecdsa_signature *sig;
     secp256k1_pubkey *pubkey;
     zend_string *msg32;
     int result = 0;
@@ -801,11 +801,7 @@ PHP_FUNCTION(secp256k1_ecdsa_verify) {
         RETURN_LONG(result);
     }
 
-    sigcpy = (secp256k1_ecdsa_signature *) emalloc(sizeof(secp256k1_ecdsa_signature));
-    secp256k1_ecdsa_signature_normalize(ctx, sigcpy, sig);
-    result = secp256k1_ecdsa_verify(ctx, sigcpy, msg32->val, pubkey);
-    efree(sigcpy);
-
+    result = secp256k1_ecdsa_verify(ctx, sig, msg32->val, pubkey);
     RETURN_LONG(result);
 }
 /* }}} */

--- a/secp256k1/tests/secp256k1_ecdsa_verify_error5.phpt
+++ b/secp256k1/tests/secp256k1_ecdsa_verify_error5.phpt
@@ -1,5 +1,5 @@
 --TEST--
-secp256k1_ecdsa_signature_normalize works, and is required for the given signature
+secp256k1_ecdsa_verify fails when the signature requires normalization
 --SKIPIF--
 <?php
 if (!extension_loaded("secp256k1")) print "skip extension not loaded";
@@ -19,25 +19,12 @@ $result = secp256k1_ecdsa_signature_parse_der($ctx, $inputSig, $sigIn);
 echo $result . PHP_EOL;
 echo get_resource_type($inputSig) . PHP_EOL;
 
-$sigOut = "";
-$result = secp256k1_ecdsa_signature_serialize_der($ctx, $sigOut, $inputSig);
-echo $result . PHP_EOL;
-echo bin2hex($sigOut) . PHP_EOL;
-
-$normalSig = null;
-$result = secp256k1_ecdsa_signature_normalize($ctx, $normalSig, $inputSig);
-echo $result . PHP_EOL;
-
-$normalOut = "";
-$result = secp256k1_ecdsa_signature_serialize_der($ctx, $normalOut, $normalSig);
-echo $result . PHP_EOL;
-echo unpack("H*", $normalOut)[1] . PHP_EOL;
-
 $pub = null;
 $result = \secp256k1_ec_pubkey_create($ctx, $pub, $priv);
 echo $result . PHP_EOL;
 
-$result = \secp256k1_ecdsa_verify($ctx, $normalSig, $msg32, $pub);
+// this *should* fail when we remove normalization from verify!
+$result = \secp256k1_ecdsa_verify($ctx, $inputSig, $msg32, $pub);
 echo $result . PHP_EOL;
 
 ?>
@@ -45,9 +32,5 @@ echo $result . PHP_EOL;
 1
 secp256k1_ecdsa_signature
 1
-30460221008a40123bd34eb158206cda02203b470615a15bd4727dbfa50a1ed367b4759c8a022100cf969c4fe1faf41bfa32297226bf3dac95eab9ca3cf81d9ee248ce6a2be5538a
-1
-1
-30450221008a40123bd34eb158206cda02203b470615a15bd4727dbfa50a1ed367b4759c8a0220306963b01e050be405cdd68dd940c25224c4231c7250829cdd899022a450edb7
-1
-1
+0
+

--- a/tests/Secp256k1EcdsaVerifyTest.php
+++ b/tests/Secp256k1EcdsaVerifyTest.php
@@ -51,20 +51,25 @@ class Secp256k1EcdsaVerifyTest extends TestCase
         $this->assertEquals(1, \secp256k1_ec_pubkey_create($context, $public, $private), 'public');
 
         /** @var resource $s */
+        /** @var resource $s1 */
         $s = null;
-        secp256k1_ecdsa_signature_parse_der($context, $s, $sig);
+        $s1 = null;
+        $this->assertEquals(1, secp256k1_ecdsa_signature_parse_der($context, $s, $sig));
+        $this->assertEquals(1, secp256k1_ecdsa_signature_normalize($context, $s1, $s));
 
-        $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $s, $msg32, $public), 'initial check');
-        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $s, '', $public), 'msg32 as empty string');
-        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $s, 1, $public), 'msg32 as 1');
+        $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $s1, $msg32, $public), 'initial check');
+        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $s1, '', $public), 'msg32 as empty string');
+        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $s1, 1, $public), 'msg32 as 1');
 
         /** @var resource $lax */
         $lax = null;
+        $lax1 = null;
         $this->assertEquals(1, \ecdsa_signature_parse_der_lax($context, $lax, $sig));
+        $this->assertEquals(1, secp256k1_ecdsa_signature_normalize($context, $lax1, $lax));
 
-        $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $lax, $msg32, $public), 'initial check');
-        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $lax, '', $public), 'msg32 as empty string');
-        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $lax, 1, $public), 'msg32 as 1');
+        $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $lax1, $msg32, $public), 'initial check');
+        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $lax1, '', $public), 'msg32 as empty string');
+        $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $lax1, 1, $public), 'msg32 as 1');
     }
 
     /**
@@ -87,11 +92,28 @@ class Secp256k1EcdsaVerifyTest extends TestCase
         /** @var resource $s */
         $s = null;
         $this->assertEquals(1, secp256k1_ecdsa_signature_parse_der($context, $s, $sig));
-        $this->assertEquals($eSigCreate, \secp256k1_ecdsa_verify($context, $s, $msg, $pubkey));
+
+        /** @var resource $normalSig */
+        $normalSig = null;
+        $normalize = secp256k1_ecdsa_signature_normalize($context, $normalSig, $s);
+        if ($normalize) {
+            if ($eSigCreate) {
+                $this->assertEquals(0, \secp256k1_ecdsa_verify($context, $s, $msg, $pubkey));
+                $this->assertEquals($eSigCreate, \secp256k1_ecdsa_verify($context, $normalSig, $msg, $pubkey));
+            }
+        } else {
+            $this->assertEquals($eSigCreate, \secp256k1_ecdsa_verify($context, $s, $msg, $pubkey));
+        }
 
         /** @var resource $lax */
         $lax = null;
         $this->assertEquals(1, \ecdsa_signature_parse_der_lax($context, $lax, $sig));
-        $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $lax, $msg, $pubkey));
+        if ($normalize) {
+            /** @var resource $normalLax */
+            secp256k1_ecdsa_signature_normalize($context, $normalLax, $s);
+            $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $normalLax, $msg, $pubkey));
+        } else {
+            $this->assertEquals(1, \secp256k1_ecdsa_verify($context, $s, $msg, $pubkey));
+        }
     }
 }


### PR DESCRIPTION
This PR removes the copy-then-normalize approach used in secp256k1_ecdsa_verify. Realistically we should leave this up to the caller. This will cause signature failures (as evidenced in the test rewrites to adjust for this) if the signature is not normalized. 

See https://github.com/Bit-Wasp/secp256k1-php/issues/70