### PR TITLE
v0.1.x: fix memleaks and avoid emalloc if not required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - nightly
+  - 7.3
 
 env:
   global:

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -473,6 +473,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_parse_der)
         zval_dtor(zSig);
         ZVAL_RES(zSig, zend_register_resource(sig, le_secp256k1_sig));
     } else {
+        // only free when operation fails, won't return this resource
         efree(sig);
     }
 
@@ -508,9 +509,9 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_der)
     if (result == 1) {
         zval_dtor(zSigOut);
         ZVAL_STRINGL(zSigOut, sigout, sigoutlen);
-    } else {
-        efree(sigout);
     }
+    // free since ZVAL_STRINGL copies bytes
+    efree(sigout);
 
     RETURN_LONG(result);
 }
@@ -545,7 +546,8 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_parse_compact)
         zval_dtor(zSig);
         ZVAL_RES(zSig, zend_register_resource(sig, le_secp256k1_sig));
     } else {
-        efree(sig);
+	// only free when operation fails, won't return this resource
+	efree(sig);
     }
 
     RETURN_LONG(result);
@@ -579,6 +581,9 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_compact)
 
     zval_dtor(zSigOut);
     ZVAL_STRINGL(zSigOut, sigOut, COMPACT_SIGNATURE_LENGTH);
+    // free since ZVAL_STRINGL copies bytes
+    efree(sigOut);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -607,6 +612,7 @@ PHP_FUNCTION(ecdsa_signature_parse_der_lax)
         zval_dtor(zSig);
         ZVAL_RES(zSig, zend_register_resource(sig, le_secp256k1_sig));
     } else {
+        // only free when operation fails, won't return this resource
         efree(sig);
     }
 
@@ -714,6 +720,7 @@ PHP_FUNCTION (secp256k1_ecdsa_sign)
         zval_dtor(zSig);
         ZVAL_RES(zSig, zend_register_resource(newsig, le_secp256k1_sig));
     } else {
+        // only free when operation fails, won't return this resource
         efree(newsig);
     }
 
@@ -780,6 +787,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_create)
         zval_dtor(zPubKey);
         ZVAL_RES(zPubKey, zend_register_resource(pubkey, le_secp256k1_pubkey));
     } else {
+        // only free when operation fails, won't return this resource
         efree(pubkey);
     }
 
@@ -820,6 +828,9 @@ PHP_FUNCTION(secp256k1_ec_privkey_negate)
 
     zval_dtor(zPrivKey);
     ZVAL_STRINGL(zPrivKey, newseckey, SECRETKEY_LENGTH);
+    // free since ZVAL_STRINGL copies bytes
+    efree(newseckey);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -875,6 +886,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_parse)
         zval_dtor(zPubKey);
         ZVAL_RES(zPubKey, zend_register_resource(pubkey, le_secp256k1_pubkey));
     } else {
+        // only free when operation fails, won't return this resource
         efree(pubkey);
     }
 
@@ -911,6 +923,9 @@ PHP_FUNCTION(secp256k1_ec_pubkey_serialize)
 
     zval_dtor(zPubOut);
     ZVAL_STRINGL(zPubOut, pubkeyout, pubkeylen);
+    // free since ZVAL_STRINGL copies bytes
+    efree(pubkeyout);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -953,6 +968,9 @@ PHP_FUNCTION(secp256k1_ec_privkey_tweak_add)
 
     zval_dtor(zSecKey);
     ZVAL_STRINGL(zSecKey, newseckey, SECRETKEY_LENGTH);
+    // free since ZVAL_STRINGL copies bytes
+    efree(newseckey);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -985,6 +1003,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_add)
     }
 
     result = secp256k1_ec_pubkey_tweak_add(ctx, pubkey, (unsigned char *)zTweak->val);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -1028,6 +1047,9 @@ PHP_FUNCTION(secp256k1_ec_privkey_tweak_mul)
 
     zval_dtor(zSecKey);
     ZVAL_STRINGL(zSecKey, newseckey, SECRETKEY_LENGTH);
+    // free since ZVAL_STRINGL copies bytes
+    efree(newseckey);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -1062,6 +1084,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_tweak_mul)
     }
 
     result = secp256k1_ec_pubkey_tweak_mul(ctx, pubkey, (unsigned char *) zTweak->val);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -1105,6 +1128,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_combine)
         zval_dtor(zPubkeyCombined);
         ZVAL_RES(zPubkeyCombined, zend_register_resource(combined, le_secp256k1_pubkey));
     } else {
+        // free when operation fails, won't return this resource
         efree(combined);
     }
 
@@ -1149,6 +1173,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_parse_compact)
         zval_dtor(zSig);
         ZVAL_RES(zSig, zend_register_resource(sig, le_secp256k1_recoverable_sig));
     } else {
+        // free when operation fails, won't return this resource
         efree(sig);
     }
 
@@ -1183,6 +1208,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_convert)
 
     zval_dtor(zNormalSig);
     ZVAL_RES(zNormalSig, zend_register_resource(nSig, le_secp256k1_sig));
+    // convert() can't fail, so we'll always return the resource here
 
     RETURN_LONG(result);
 }
@@ -1214,9 +1240,13 @@ PHP_FUNCTION(secp256k1_ecdsa_recoverable_signature_serialize_compact)
     result = secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, recsig);
 
     zval_dtor(zSigOut);
-    zval_dtor(zRecId);
     ZVAL_STRINGL(zSigOut, sig, COMPACT_SIGNATURE_LENGTH);
+    // free since ZVAL_STRINGL copies bytes
+    efree(sig);
+
+    zval_dtor(zRecId);
     ZVAL_LONG(zRecId, recid);
+
     RETURN_LONG(result);
 }
 /* }}} */
@@ -1255,6 +1285,7 @@ PHP_FUNCTION(secp256k1_ecdsa_sign_recoverable)
         zval_dtor(zSig);
         ZVAL_RES(zSig, zend_register_resource(newsig, le_secp256k1_recoverable_sig));
     } else {
+        // free when operation fails, won't return this resource
         efree(newsig);
     }
 
@@ -1291,6 +1322,7 @@ PHP_FUNCTION(secp256k1_ecdsa_recover)
         zval_dtor(zPubKey);
         ZVAL_RES(zPubKey, zend_register_resource(pubkey, le_secp256k1_pubkey));
     } else {
+        // free when operation fails, won't return this resource
         efree(pubkey);
     }
 


### PR DESCRIPTION
Fixes https://github.com/Bit-Wasp/secp256k1-php/issues/131

First commit fixes original report, by adding efree where appropriate. The second commit avoids using the heap where possible.