### PR TITLE
secp256k1_ecdh: support callback with custom hash function and extra data

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,5 @@
 ignore:
  - secp256k1/lax_der.h
+
+fixes:
+ - "/usr/src/php/ext/secp256k1::secp256k1"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,2 @@
 ignore:
  - secp256k1/lax_der.h
-

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
 ignore:
  - secp256k1/lax_der.h
 
-fixes:
- - "/usr/src/php/ext/secp256k1::secp256k1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 env:
   global:
-   - SECP256K1_COMMIT=cd329dbc3eaf096ae007e807b86b6f5947621ee3
+   - SECP256K1_COMMIT=b19c000063be11018b4d1a6b0a85871ab9d0bdcf
    - DOCKER_CACHE_DIR=/home/travis/docker
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ script:
   - travis/run_coverage_test.sh || exit 1
   - travis/validate_examples.sh || exit 1
 after_script:
+    - ls secp256k1/coverage.output
     - curl -s https://codecov.io/bash > ./codecov
     - chmod +x ./codecov
-    - ./codecov -s travis/phpqa/output
+    - ./codecov -s secp256k1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 env:
   global:
-   - SECP256K1_COMMIT=b19c000063be11018b4d1a6b0a85871ab9d0bdcf
+   - SECP256K1_COMMIT=fa3301713549d118e57ebe6551d062903ddd6b63
    - DOCKER_CACHE_DIR=/home/travis/docker
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,4 @@ script:
   - travis/run_coverage_test.sh || exit 1
   - travis/validate_examples.sh || exit 1
 after_script:
-    - ls secp256k1/coverage.output
-    - curl -s https://codecov.io/bash > ./codecov
-    - chmod +x ./codecov
-    - ./codecov -s secp256k1
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,6 @@ script:
   - travis/run_coverage_test.sh || exit 1
   - travis/validate_examples.sh || exit 1
 after_script:
-    - bash <(curl -s https://codecov.io/bash)
+    - curl -s https://codecov.io/bash > ./codecov
+    - chmod +x ./codecov
+    - ./codecov -s travis/phpqa/output

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -1506,7 +1506,7 @@ PHP_FUNCTION(secp256k1_ecdh)
     secp256k1_pubkey *pubkey;
     zend_string *privKey;
     zval* data = NULL;
-    long output_len = 32;
+    long output_len;
     zend_fcall_info fci;
     zend_fcall_info_cache fcc;
     php_callback callback;
@@ -1520,6 +1520,7 @@ PHP_FUNCTION(secp256k1_ecdh)
         if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS", &zCtx, &zResult, &zPubKey, &privKey) == FAILURE) {
             RETURN_LONG(result);
         }
+        output_len = 32;
     }
 
     if ((ctx = php_get_secp256k1_context(zCtx)) == NULL) {
@@ -1528,10 +1529,6 @@ PHP_FUNCTION(secp256k1_ecdh)
 
     if ((pubkey = php_get_secp256k1_pubkey(zPubKey)) == NULL) {
         RETURN_LONG(result);
-    }
-
-    if (ZEND_NUM_ARGS() < 5) {
-        output_len = 32;
     }
 
     unsigned char resultChars[output_len];

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -1511,13 +1511,9 @@ PHP_FUNCTION(secp256k1_ecdh)
     zend_fcall_info_cache fcc;
     php_callback callback;
     int result = 0;
-    if (ZEND_NUM_ARGS() == 7) {
+    if (ZEND_NUM_ARGS() == 6 || ZEND_NUM_ARGS() == 7) {
         if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS|flz",
             &zCtx, &zResult, &zPubKey, &privKey, &fci, &fcc, &output_len, &data) == FAILURE) {
-            RETURN_LONG(result);
-        }
-    } else if (ZEND_NUM_ARGS() == 6) {
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/rS|fl", &zCtx, &zResult, &zPubKey, &privKey, &fci, &fcc, &output_len) == FAILURE) {
             RETURN_LONG(result);
         }
     } else {

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -1490,9 +1490,9 @@ static int trigger_callback(unsigned char* output, const unsigned char *x,
         }
     }
 
-    zval_dtor(&args[0]);
-    zval_dtor(&args[1]);
-    zval_dtor(&args[2]);
+    for (i = 0; i < callback->fci->param_count; i++) {
+        zval_dtor(&args[i]);
+    }
 
     return result;
 }

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -1437,18 +1437,15 @@ typedef struct php_callback {
 static int trigger_callback(unsigned char* output, const unsigned char *x,
                             const unsigned char* y, void *data) {
     php_callback* callback;
-
-    callback = (php_callback*) data;
     zend_string* output_str;
     zval retval, zvalout;
     zval args[4];
     int result, i;
-    int arg_count = (callback->data != NULL) ? 4 : 3;
 
+    callback = (php_callback*) data;
     callback->fci->size = sizeof(*(callback->fci));
     callback->fci->object = NULL;
     callback->fci->retval = &retval;
-    callback->fci->param_count = arg_count;
     callback->fci->params = args;
 
     ZVAL_NEW_STR(&zvalout, zend_string_init("", 0, 0));
@@ -1456,9 +1453,12 @@ static int trigger_callback(unsigned char* output, const unsigned char *x,
     ZVAL_NEW_REF(&args[0], &zvalout);
     ZVAL_STR(&args[1], zend_string_init(x, 32, 0));
     ZVAL_STR(&args[2], zend_string_init(y, 32, 0));
-    if (arg_count == 4) {
+    if (callback->data != NULL) {
+        callback->fci->param_count = 4;
         zval* data = callback->data;
         args[3] = *data;
+    } else {
+        callback->fci->param_count = 3;
     }
 
     result = zend_call_function(callback->fci, callback->fcc) == SUCCESS;

--- a/secp256k1/tests/secp256k1_ecdh_customhash_can_fail.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_can_fail.phpt
@@ -1,0 +1,48 @@
+--TEST--
+secp256k1_ecdh - a custom hash function can cause operation to fail
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$callbackReturning = function ($returnVal) {
+    return function (&$output, $x, $y) use ($returnVal) {
+        echo "in callback\n";
+        return $returnVal;
+    };
+};
+$cbFalse = function (&$output, $x, $y) {
+    return false;
+};
+$cbZero = function (&$output, $x, $y) {
+    return 0;
+};
+echo "return 0\n";
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $cbZero, NULL);
+echo $result . PHP_EOL;
+
+echo "return false\n";
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $cbFalse, NULL);
+echo $result . PHP_EOL;
+
+?>
+--EXPECT--
+1
+return 0
+0
+return false
+0

--- a/secp256k1/tests/secp256k1_ecdh_customhash_can_fail.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_can_fail.phpt
@@ -31,12 +31,12 @@ $cbZero = function (&$output, $x, $y) {
 };
 echo "return 0\n";
 $secret = '';
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $cbZero, NULL);
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $cbZero, 32, NULL);
 echo $result . PHP_EOL;
 
 echo "return false\n";
 $secret = '';
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $cbFalse, NULL);
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $cbFalse, 32, NULL);
 echo $result . PHP_EOL;
 
 ?>

--- a/secp256k1/tests/secp256k1_ecdh_customhash_equivalent_sha256.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_equivalent_sha256.phpt
@@ -1,0 +1,46 @@
+--TEST--
+secp256k1_ecdh - can write equivalent hash fxn to default
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$hashFxn = function (&$output, $x, $y, $data) {
+    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    $ctx = hash_init('sha256', 0);
+    hash_update($ctx, pack("C", $version));
+    hash_update($ctx, $x);
+    $output = hash_final($ctx, true);
+    return 1;
+};
+
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 32, NULL);
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2);
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+?>
+--EXPECT--
+1
+1
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec
+1
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec
+

--- a/secp256k1/tests/secp256k1_ecdh_customhash_equivalent_sha256_returntrue.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_equivalent_sha256_returntrue.phpt
@@ -1,0 +1,46 @@
+--TEST--
+secp256k1_ecdh - can write equivalent hash fxn to default. callback returns true, not 1.
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$hashFxn = function (&$output, $x, $y, $data) {
+    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    $ctx = hash_init('sha256', 0);
+    hash_update($ctx, pack("C", $version));
+    hash_update($ctx, $x);
+    $output = hash_final($ctx, true);
+    return true;
+};
+
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 32, NULL);
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2);
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+?>
+--EXPECT--
+1
+1
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec
+1
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec
+

--- a/secp256k1/tests/secp256k1_ecdh_customhash_equivalent_sha256_returntrue.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_equivalent_sha256_returntrue.phpt
@@ -18,7 +18,7 @@ $result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
 echo $result . PHP_EOL;
 
 // Function we suppose is equivalent to upstreams default hash fxn
-$hashFxn = function (&$output, $x, $y, $data) {
+$hashFxn = function (&$output, $x, $y) {
     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
     $ctx = hash_init('sha256', 0);
     hash_update($ctx, pack("C", $version));
@@ -28,7 +28,7 @@ $hashFxn = function (&$output, $x, $y, $data) {
 };
 
 $secret = '';
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 32, NULL);
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 32);
 echo $result . PHP_EOL;
 echo unpack("H*", $secret)[1].PHP_EOL;
 

--- a/secp256k1/tests/secp256k1_ecdh_customhash_example.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_example.phpt
@@ -1,0 +1,39 @@
+--TEST--
+secp256k1_ecdh - custom hash functions can be used (not 32 bytes)
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$hashFxn = function (&$output, $x, $y, $data) {
+    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    $ctx = hash_init('sha384', 0);
+    hash_update($ctx, pack("C", $version));
+    hash_update($ctx, $x);
+    $output = hash_final($ctx, true);
+    return 1;
+};
+
+$secret = '';
+// it's sha384, but 384 is the number of bits. divide by 8 for bytes.
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 384/8, NULL);
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+?>
+--EXPECT--
+1
+1
+774b629c86a6dbbcaa384bbb8a5fd34ca4c96431151a8da482865377dacc86d7638edb0f4761d0abca7853d156c4a46a

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_int.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_int.phpt
@@ -1,5 +1,5 @@
 --TEST--
-secp256k1_ecdh - custom hash functions can be used (not 32 bytes)
+secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be int
 --SKIPIF--
 <?php
 if (!extension_loaded("secp256k1")) print "skip extension not loaded";
@@ -10,6 +10,7 @@ if (!extension_loaded("secp256k1")) print "skip extension not loaded";
 $context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 $priv1 = str_pad('', 32, "\x41");
 $priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
 
 /** @var resource $pub1 */
 $pub1 = null;
@@ -17,9 +18,12 @@ $result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
 echo $result . PHP_EOL;
 
 // Function we suppose is equivalent to upstreams default hash fxn
-$hashFxn = function (&$output, $x, $y) {
+$hashFxn = function (&$output, string $x, string $y, int $data) {
     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
-    $ctx = hash_init('sha384', 0);
+    echo "secret x: ".bin2hex($x).PHP_EOL;
+    echo "secret y: ".bin2hex($y).PHP_EOL;
+    echo "extra: "; var_dump($data);
+    $ctx = hash_init('sha256', 0);
     hash_update($ctx, pack("C", $version));
     hash_update($ctx, $x);
     $output = hash_final($ctx, true);
@@ -27,13 +31,15 @@ $hashFxn = function (&$output, $x, $y) {
 };
 
 $secret = '';
-// it's sha384, but 384 is the number of bits. divide by 8 for bytes.
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 384/8);
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 256/8, 128);
 echo $result . PHP_EOL;
 echo unpack("H*", $secret)[1].PHP_EOL;
 
 ?>
 --EXPECT--
 1
+secret x: 17d1ee664632a741f87da19c82d4fc8352368305062370769cf78779ad6ad250
+secret y: 70d091c815ec945c61c282e60be6da41423b00b415d76e44ae58a343d670797b
+extra: int(128)
 1
-774b629c86a6dbbcaa384bbb8a5fd34ca4c96431151a8da482865377dacc86d7638edb0f4761d0abca7853d156c4a46a
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_object.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_object.phpt
@@ -1,5 +1,5 @@
 --TEST--
-secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be int
+secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be stdClass
 --SKIPIF--
 <?php
 if (!extension_loaded("secp256k1")) print "skip extension not loaded";

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_object.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_object.phpt
@@ -1,5 +1,5 @@
 --TEST--
-secp256k1_ecdh - can write equivalent hash fxn to default
+secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be int
 --SKIPIF--
 <?php
 if (!extension_loaded("secp256k1")) print "skip extension not loaded";
@@ -18,8 +18,11 @@ $result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
 echo $result . PHP_EOL;
 
 // Function we suppose is equivalent to upstreams default hash fxn
-$hashFxn = function (&$output, $x, $y) {
+$hashFxn = function (&$output, string $x, string $y, \stdClass $data) {
     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    echo "secret x: ".bin2hex($x).PHP_EOL;
+    echo "secret y: ".bin2hex($y).PHP_EOL;
+    echo "extra: "; var_dump($data);
     $ctx = hash_init('sha256', 0);
     hash_update($ctx, pack("C", $version));
     hash_update($ctx, $x);
@@ -28,19 +31,17 @@ $hashFxn = function (&$output, $x, $y) {
 };
 
 $secret = '';
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 32, NULL);
-echo $result . PHP_EOL;
-echo unpack("H*", $secret)[1].PHP_EOL;
-
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2);
+$obj = new \stdClass();
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 256/8, $obj);
 echo $result . PHP_EOL;
 echo unpack("H*", $secret)[1].PHP_EOL;
 
 ?>
 --EXPECT--
 1
+secret x: 17d1ee664632a741f87da19c82d4fc8352368305062370769cf78779ad6ad250
+secret y: 70d091c815ec945c61c282e60be6da41423b00b415d76e44ae58a343d670797b
+extra: object(stdClass)#2 (0) {
+}
 1
 238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec
-1
-238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec
-

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_string.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_string.phpt
@@ -1,5 +1,5 @@
 --TEST--
-secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be int
+secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be string
 --SKIPIF--
 <?php
 if (!extension_loaded("secp256k1")) print "skip extension not loaded";

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_string.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_typehint_with_data_string.phpt
@@ -1,5 +1,5 @@
 --TEST--
-secp256k1_ecdh - custom hash functions can be used (not 32 bytes)
+secp256k1_ecdh - custom hash function can typehint X / Y as string, and data can be int
 --SKIPIF--
 <?php
 if (!extension_loaded("secp256k1")) print "skip extension not loaded";
@@ -10,6 +10,7 @@ if (!extension_loaded("secp256k1")) print "skip extension not loaded";
 $context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 $priv1 = str_pad('', 32, "\x41");
 $priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
 
 /** @var resource $pub1 */
 $pub1 = null;
@@ -17,9 +18,12 @@ $result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
 echo $result . PHP_EOL;
 
 // Function we suppose is equivalent to upstreams default hash fxn
-$hashFxn = function (&$output, $x, $y) {
+$hashFxn = function (&$output, string $x, string $y, string $data) {
     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
-    $ctx = hash_init('sha384', 0);
+    echo "secret x: ".bin2hex($x).PHP_EOL;
+    echo "secret y: ".bin2hex($y).PHP_EOL;
+    echo "extra: "; var_dump($data);
+    $ctx = hash_init('sha256', 0);
     hash_update($ctx, pack("C", $version));
     hash_update($ctx, $x);
     $output = hash_final($ctx, true);
@@ -27,13 +31,15 @@ $hashFxn = function (&$output, $x, $y) {
 };
 
 $secret = '';
-// it's sha384, but 384 is the number of bits. divide by 8 for bytes.
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 384/8);
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 256/8, "AAAA");
 echo $result . PHP_EOL;
 echo unpack("H*", $secret)[1].PHP_EOL;
 
 ?>
 --EXPECT--
 1
+secret x: 17d1ee664632a741f87da19c82d4fc8352368305062370769cf78779ad6ad250
+secret y: 70d091c815ec945c61c282e60be6da41423b00b415d76e44ae58a343d670797b
+extra: string(4) "AAAA"
 1
-774b629c86a6dbbcaa384bbb8a5fd34ca4c96431151a8da482865377dacc86d7638edb0f4761d0abca7853d156c4a46a
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_use_vars.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_use_vars.phpt
@@ -1,0 +1,41 @@
+--TEST--
+secp256k1_ecdh - custom hash function can use the use keyword
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+$dataLen = 256/8;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$hashFxn = function (&$output, $x, $y, $data) use ($dataLen) {
+    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    $ctx = hash_init('sha256', 0);
+    hash_update($ctx, pack("C", $version));
+    hash_update($ctx, $x);
+    $output = hash_final($ctx, true);
+    return $dataLen == strlen($output);
+};
+
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, );
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+?>
+--EXPECT--
+1
+1
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_use_vars.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_use_vars.phpt
@@ -30,7 +30,7 @@ $hashFxn = function (&$output, $x, $y, $data) use ($dataLen) {
 };
 
 $secret = '';
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, );
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn);
 echo $result . PHP_EOL;
 echo unpack("H*", $secret)[1].PHP_EOL;
 

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_use_vars.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_can_use_vars.phpt
@@ -20,17 +20,17 @@ echo $result . PHP_EOL;
 $dataLen = 256/8;
 
 // Function we suppose is equivalent to upstreams default hash fxn
-$hashFxn = function (&$output, $x, $y, $data) use ($dataLen) {
+$hashFxn = function (&$output, $x, $y) {
     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
     $ctx = hash_init('sha256', 0);
     hash_update($ctx, pack("C", $version));
     hash_update($ctx, $x);
     $output = hash_final($ctx, true);
-    return $dataLen == strlen($output);
+    return 1;
 };
 
 $secret = '';
-$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn);
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, $dataLen);
 echo $result . PHP_EOL;
 echo unpack("H*", $secret)[1].PHP_EOL;
 

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_must_write_correct_len.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_must_write_correct_len.phpt
@@ -1,0 +1,38 @@
+--TEST--
+secp256k1_ecdh - custom hash function must write correct number of bytes
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$hashFxn = function (&$output, $x, $y, $data) {
+    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    $ctx = hash_init('sha256', 0);
+    hash_update($ctx, pack("C", $version));
+    hash_update($ctx, $x);
+    $output = substr(hash_final($ctx, true), 0, -1);
+    return 1;
+};
+
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 256/8);
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+?>
+--EXPECT--
+1
+0

--- a/secp256k1/tests/secp256k1_ecdh_customhash_fxn_must_write_correct_len.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_fxn_must_write_correct_len.phpt
@@ -18,7 +18,7 @@ $result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
 echo $result . PHP_EOL;
 
 // Function we suppose is equivalent to upstreams default hash fxn
-$hashFxn = function (&$output, $x, $y, $data) {
+$hashFxn = function (&$output, $x, $y) {
     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
     $ctx = hash_init('sha256', 0);
     hash_update($ctx, pack("C", $version));

--- a/secp256k1/tests/secp256k1_ecdh_customhash_receives_x_y_and_data.phpt
+++ b/secp256k1/tests/secp256k1_ecdh_customhash_receives_x_y_and_data.phpt
@@ -1,0 +1,45 @@
+--TEST--
+secp256k1_ecdh - custom hash function receives X Y and DATA values
+--SKIPIF--
+<?php
+if (!extension_loaded("secp256k1")) print "skip extension not loaded";
+?>
+--FILE--
+<?php
+
+$context = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+$priv1 = str_pad('', 32, "\x41");
+$priv2 = str_pad('', 32, "\x40");
+$expectedSecret = '238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec';
+
+/** @var resource $pub1 */
+$pub1 = null;
+$result = \secp256k1_ec_pubkey_create($context, $pub1, $priv1);
+echo $result . PHP_EOL;
+
+// Function we suppose is equivalent to upstreams default hash fxn
+$hashFxn = function (&$output, $x, $y, $data) {
+    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+    echo "secret x: ".bin2hex($x).PHP_EOL;
+    echo "secret y: ".bin2hex($y).PHP_EOL;
+    echo "extra: "; var_dump($data);
+    $ctx = hash_init('sha256', 0);
+    hash_update($ctx, pack("C", $version));
+    hash_update($ctx, $x);
+    $output = hash_final($ctx, true);
+    return 1;
+};
+
+$secret = '';
+$result = \secp256k1_ecdh($context, $secret, $pub1, $priv2, $hashFxn, 256/8, 'AAAA');
+echo $result . PHP_EOL;
+echo unpack("H*", $secret)[1].PHP_EOL;
+
+?>
+--EXPECT--
+1
+secret x: 17d1ee664632a741f87da19c82d4fc8352368305062370769cf78779ad6ad250
+secret y: 70d091c815ec945c61c282e60be6da41423b00b415d76e44ae58a343d670797b
+extra: string(4) "AAAA"
+1
+238c14f420887f8e9bfa78bc9bdded1975f0bb6384e33b4ebbf7a8c776844aec

--- a/stubs/functions.php
+++ b/stubs/functions.php
@@ -317,7 +317,21 @@ function secp256k1_ecdsa_sign_recoverable($context, &$ecdsaRecoverableSignatureO
  */
 function secp256k1_ecdsa_recover($context, &$ecPublicKey, $ecdsaRecoverableSignature, string $msg32): int {}
 /**
- * Compute an EC Diffie-Hellman secret in constant time
+ * Compute an EC Diffie-Hellman secret in constant time.
+ * A custom hash function may be provided as the 5th
+ * argument, once the length of data to be written is
+ * passed as the 6th argument.
+ * Optional additional data may be provided to the callback
+ * via the 7th argument.
+ * The default hash function is essentially the following:
+ * function (&$output, $x, $y, $data) {
+ *     $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
+ *     $ctx = hash_init('sha256', 0);
+ *     hash_update($ctx, pack("C", $version));
+ *     hash_update($ctx, $x);
+ *     $output = hash_final($ctx, true);
+ *     return 1;
+ * };
  * 
  * Returns: 1: exponentiation was successful
  *          0: scalar was invalid (zero or overflow)

--- a/stubs/functions.php
+++ b/stubs/functions.php
@@ -326,6 +326,9 @@ function secp256k1_ecdsa_recover($context, &$ecPublicKey, $ecdsaRecoverableSigna
  * @param string $result
  * @param resource $ecPublicKey
  * @param string $privKey
+ * @param callable|null $hashfxn
+ * @param int|null $outputLen
+ * @param  $data
  * @return int
  */
-function secp256k1_ecdh($context, string &$result, $ecPublicKey, string $privKey): int {}
+function secp256k1_ecdh($context, string &$result, $ecPublicKey, string $privKey, ?callable $hashfxn, ?int $outputLen, $data): int {}

--- a/travis/phpqa/Dockerfile
+++ b/travis/phpqa/Dockerfile
@@ -19,7 +19,7 @@ ENV PHPIZE_DEPS \
 		make \
 		pkg-config \
 		re2c
-ENV SECP256K1_COMMIT=cd329dbc3eaf096ae007e807b86b6f5947621ee3
+ENV SECP256K1_COMMIT=fa3301713549d118e57ebe6551d062903ddd6b63
 ENV PHP_INI_DIR /usr/local/etc/php
 ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
 ENV PHP_CPPFLAGS="$PHP_CFLAGS"

--- a/travis/phpqa/Dockerfile
+++ b/travis/phpqa/Dockerfile
@@ -73,7 +73,7 @@ RUN set -xe; \
 		wget -O php.tar.xz.asc "$PHP_ASC_URL"; \
 		export GNUPGHOME="$(mktemp -d)"; \
 		for key in $GPG_KEYS; do \
-			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+			gpg --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
 		rm -r "$GNUPGHOME"; \

--- a/travis/phpqa/scripts/coverage.sh
+++ b/travis/phpqa/scripts/coverage.sh
@@ -33,3 +33,6 @@ rm configure && ./buildconf --force
 && ls -lsh ext/secp256k1 \
 && make lcov TESTS=ext/secp256k1/tests \
 && gcov lcov_data/ext/secp256k1/secp256k1.c -f > coverage.output
+
+echo $PWD
+cp coverage.output ext/secp256k1/

--- a/travis/phpqa/scripts/coverage.sh
+++ b/travis/phpqa/scripts/coverage.sh
@@ -35,4 +35,5 @@ rm configure && ./buildconf --force
 && gcov lcov_data/ext/secp256k1/secp256k1.c -f > coverage.output
 
 echo $PWD
-cp coverage.output ext/secp256k1/
+cp -v coverage.output ext/secp256k1/
+cp -v secp256k1.c.gcov ext/secp256k1/

--- a/travis/stubs/config.json
+++ b/travis/stubs/config.json
@@ -69,7 +69,7 @@
     "doc": "Add a number of public keys together.\n\nReturns: 1: the sum of the public keys is valid.\n         0: the sum of the public keys is not valid.\n"
   },
   "secp256k1_ecdh": {
-    "doc": "Compute an EC Diffie-Hellman secret in constant time\n\nReturns: 1: exponentiation was successful\n         0: scalar was invalid (zero or overflow)\n"
+    "doc": "Compute an EC Diffie-Hellman secret in constant time.\nA custom hash function may be provided as the 5th\nargument, once the length of data to be written is\npassed as the 6th argument.\nOptional additional data may be provided to the callback\nvia the 7th argument.\nThe default hash function is essentially the following:\nfunction (&$output, $x, $y, $data) {\n    $version = 0x02 | (unpack(\"C\", $y[31])[1] & 0x01);\n    $ctx = hash_init('sha256', 0);\n    hash_update($ctx, pack(\"C\", $version));\n    hash_update($ctx, $x);\n    $output = hash_final($ctx, true);\n    return 1;\n};\n\nReturns: 1: exponentiation was successful\n         0: scalar was invalid (zero or overflow)\n"
   },
   "secp256k1_ecdsa_recoverable_signature_parse_compact": {
     "doc": "Parse a compact ECDSA signature (64 bytes + recovery id).\n\nReturns: 1 when the signature could be parsed, 0 otherwise\n"


### PR DESCRIPTION
Adds support for latest secp256k1 ECDH api, introducing three extra parameters (hashfxn, size of hashed data, and arbitrary data)

Internally, secp256k1_ecdh implements the following routine in C as a default hash implementation. It hashes the compressed elliptic curve point.

```php
function ecdhHashFunction(&$output, $x, $y, $data) {
    $version = 0x02 | (unpack("C", $y[31])[1] & 0x01);
    $ctx = hash_init('sha256', 0);
    hash_update($ctx, pack("C", $version));
    hash_update($ctx, $x);
    $output = hash_final($ctx, true);
    return 1;
};
```

The API is now changed for ecdh, but luckily enough the change is backwards compatible with existing usage!

Using the internal implementation, we have the same function call as without this PR:
`$result = secp256k1_ecdh($ctx, $result, $privKey, $pubKey);`

To instead use a custom hash function, you can pass a callable into the function. It MUST have the same API as the function above: 
`$result = secp256k1_ecdh($ctx, $result, $privKey, $pubKey, 'ecdhHashFunction', $hashOutputLength);`
`$result = secp256k1_ecdh($ctx, $result, $privKey, $pubKey, $anonymousFxn, $hashOutputLength, $extraData);`
etc

The hashing function accepts an arbitrary data argument. Maybe you need to pass an array, a secp context, or something your algorithm requires, without requiring closures & `use ($extra)`
`$result = secp256k1_ecdh($ctx, $result, $privKey, $pubKey, 'ecdhHashFunction', $someOtherVar);`

Notes:
Internally, we always make use of the arbitrary data pointer to pass PHP function call information to trigger_callback. This data structure contains the function call info, and a `zval*` in case the user provided their own arbitrary data parameter. This is how the parameter is passed into the callback.

Fixes #124