### PR TITLE
V0.2 avoid variable length array

### DIFF
--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -1208,10 +1208,12 @@ PHP_FUNCTION(secp256k1_ec_pubkey_combine)
 
     arr_hash = Z_ARRVAL_P(arr);
     array_count = (size_t) zend_hash_num_elements(arr_hash);
-    const secp256k1_pubkey * pubkeys[array_count];
+    // emalloc terminates the request if memory can't be allocated.
+    const secp256k1_pubkey ** pubkeys = emalloc(sizeof(secp256k1_pubkey *) * array_count);
 
     ZEND_HASH_FOREACH_KEY_VAL(arr_hash, i, arrayKeyStr, arrayPubKey) {
         if ((ptr = php_get_secp256k1_pubkey(arrayPubKey)) == NULL) {
+            efree(pubkeys);
             RETURN_LONG(result);
         }
 
@@ -1227,6 +1229,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_combine)
         // free when operation fails, won't return this resource
         efree(combined);
     }
+    efree(pubkeys);
 
     RETURN_LONG(result);
 }

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -1034,7 +1034,7 @@ PHP_FUNCTION(secp256k1_ec_pubkey_serialize)
     }
 
     pubkeylen = (flags & SECP256K1_EC_COMPRESSED != 0) ? PUBKEY_COMPRESSED_LENGTH : PUBKEY_UNCOMPRESSED_LENGTH;
-    unsigned char pubkeyout[pubkeylen];
+    unsigned char pubkeyout[PUBKEY_UNCOMPRESSED_LENGTH];
     result = secp256k1_ec_pubkey_serialize(ctx, pubkeyout, &pubkeylen, pubkey, flags);
 
     zval_dtor(zPubOut);

--- a/secp256k1/secp256k1.c
+++ b/secp256k1/secp256k1.c
@@ -623,7 +623,7 @@ PHP_FUNCTION(secp256k1_ecdsa_signature_serialize_der)
     secp256k1_context *ctx;
     secp256k1_ecdsa_signature *sig;
     size_t sigoutlen = MAX_SIGNATURE_LENGTH;
-    unsigned char sigout[sigoutlen];
+    unsigned char sigout[MAX_SIGNATURE_LENGTH];
     int result = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rz/r", &zCtx, &zSigOut, &zSig) == FAILURE) {


### PR DESCRIPTION
use emalloc in an instance where array length is controlled by user input. also, use constants instead of variables.